### PR TITLE
CFE-4333: Implemented option to pretty print blocks, patches & snapshots

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -41,6 +41,7 @@ AM_CONDITIONAL([NDEBUG], [test x"$debug" = x"no"])
 
 # Config constants.
 AC_DEFINE([LCH_DEFAULT_MAX_CHAIN_LENGTH], 2048, [Default max chain length used in block garbage collector])
+AC_DEFINE([LCH_JSON_PRETTY_INDENT_SIZE], 2, [Indent size used when composing pretty JSON])
 
 # pkg-check modules.
 PKG_CHECK_MODULES([CHECK], [check])

--- a/lib/block.c
+++ b/lib/block.c
@@ -66,11 +66,14 @@ LCH_Json *LCH_BlockCreate(const char *const parent_id,
   return block;
 }
 
-bool LCH_BlockStore(const char *const work_dir, const LCH_Json *const block) {
+bool LCH_BlockStore(const LCH_Instance *const instance,
+                    const LCH_Json *const block) {
   assert(block != NULL);
-  assert(work_dir != NULL);
 
-  LCH_Buffer *const json = LCH_JsonCompose(block, false);
+  const char *const work_dir = LCH_InstanceGetWorkDirectory(instance);
+  const bool pretty_print = LCH_InstancePrettyPrint(instance);
+
+  LCH_Buffer *const json = LCH_JsonCompose(block, pretty_print);
   if (json == NULL) {
     return false;
   }

--- a/lib/block.c
+++ b/lib/block.c
@@ -70,7 +70,7 @@ bool LCH_BlockStore(const char *const work_dir, const LCH_Json *const block) {
   assert(block != NULL);
   assert(work_dir != NULL);
 
-  LCH_Buffer *const json = LCH_JsonCompose(block);
+  LCH_Buffer *const json = LCH_JsonCompose(block, false);
   if (json == NULL) {
     return false;
   }

--- a/lib/block.h
+++ b/lib/block.h
@@ -3,10 +3,11 @@
 
 #include <stdbool.h>
 
+#include "instance.h"
 #include "json.h"
 
 LCH_Json *LCH_BlockCreate(const char *parent_id, LCH_Json *const payload);
-bool LCH_BlockStore(const char *const work_dir, const LCH_Json *block);
+bool LCH_BlockStore(const LCH_Instance *const instance, const LCH_Json *block);
 LCH_Json *LCH_BlockLoad(const char *work_dir, const char *block_id);
 const char *LCH_BlockGetParentBlockIdentifier(const LCH_Json *block);
 bool LCH_BlockIsGenisisBlockIdentifier(const char *block_id);

--- a/lib/instance.c
+++ b/lib/instance.c
@@ -112,7 +112,7 @@ LCH_Instance *LCH_InstanceLoad(const char *const work_dir) {
       if (pretty_print == NULL) {
         LCH_InstanceDestroy(instance);
         LCH_JsonDestroy(config);
-        return false;
+        return NULL;
       }
       if (LCH_JsonIsTrue(pretty_print)) {
         instance->pretty_print = true;
@@ -122,6 +122,9 @@ LCH_Instance *LCH_InstanceLoad(const char *const work_dir) {
             "Illegal value for config[\"pretty_print\"]: "
             "Expected type true or false, found %s",
             type);
+        LCH_InstanceDestroy(instance);
+        LCH_JsonDestroy(config);
+        return NULL;
       }
     }
     LCH_LOG_DEBUG("config[\"pretty_print\"] = %s",

--- a/lib/instance.c
+++ b/lib/instance.c
@@ -216,7 +216,7 @@ const char *LCH_InstanceGetWorkDirectory(const LCH_Instance *const self) {
   return self->work_dir;
 }
 
-size_t LCH_InstaceGetMaxChainLength(const LCH_Instance *instance) {
+size_t LCH_InstanceGetMaxChainLength(const LCH_Instance *const instance) {
   assert(instance != NULL);
   return instance->max_chain_length;
 }

--- a/lib/instance.h
+++ b/lib/instance.h
@@ -44,4 +44,6 @@ const char *LCH_InstanceGetWorkDirectory(const LCH_Instance *instance);
 
 size_t LCH_InstaceGetMaxChainLength(const LCH_Instance *instance);
 
+bool LCH_InstancePrettyPrint(const LCH_Instance *instance);
+
 #endif  // _LEECH_INSTANCE_H

--- a/lib/instance.h
+++ b/lib/instance.h
@@ -42,7 +42,7 @@ const LCH_List *LCH_InstanceGetTables(const LCH_Instance *instance);
  */
 const char *LCH_InstanceGetWorkDirectory(const LCH_Instance *instance);
 
-size_t LCH_InstaceGetMaxChainLength(const LCH_Instance *instance);
+size_t LCH_InstanceGetMaxChainLength(const LCH_Instance *instance);
 
 bool LCH_InstancePrettyPrint(const LCH_Instance *instance);
 

--- a/lib/json.h
+++ b/lib/json.h
@@ -609,7 +609,7 @@ LCH_Json *LCH_JsonParseFile(const char *filename);
  * @note Unlike other JSON composers, the returned buffer can contain non ASCII
  *       characters.
  */
-LCH_Buffer *LCH_JsonCompose(const LCH_Json *json);
+LCH_Buffer *LCH_JsonCompose(const LCH_Json *json, bool pretty);
 
 /**
  * @brief Compose JSON element into JSON formatted file.
@@ -619,7 +619,8 @@ LCH_Buffer *LCH_JsonCompose(const LCH_Json *json);
  * @note Unlike other JSON composers, the returned buffer can contain non ASCII
  *       characters.
  */
-bool LCH_JsonComposeFile(const LCH_Json *json, const char *filename);
+bool LCH_JsonComposeFile(const LCH_Json *json, const char *filename,
+                         bool pretty);
 
 /****************************************************************************/
 

--- a/lib/leech.c
+++ b/lib/leech.c
@@ -18,7 +18,7 @@
 
 static bool CollectGarbage(const LCH_Instance *const instance) {
   const char *const work_dir = LCH_InstanceGetWorkDirectory(instance);
-  const size_t max_chain_length = LCH_InstaceGetMaxChainLength(instance);
+  const size_t max_chain_length = LCH_InstanceGetMaxChainLength(instance);
 
   char *block_id = LCH_HeadGet("HEAD", work_dir);
   if (block_id == NULL) {

--- a/lib/leech.c
+++ b/lib/leech.c
@@ -111,7 +111,9 @@ static bool CollectGarbage(const LCH_Instance *const instance) {
 
 static bool Commit(const LCH_Instance *const instance) {
   const char *const work_dir = LCH_InstanceGetWorkDirectory(instance);
+  const bool pretty_print = LCH_InstancePrettyPrint(instance);
   const LCH_List *const table_defs = LCH_InstanceGetTables(instance);
+
   size_t n_tables = LCH_ListLength(table_defs);
   size_t tot_inserts = 0, tot_deletes = 0, tot_updates = 0;
 
@@ -184,7 +186,8 @@ static bool Commit(const LCH_Instance *const instance) {
     /************************************************************************/
 
     if (num_inserts > 0 || num_deletes > 0 || num_updates > 0) {
-      if (!LCH_TableStoreNewState(table_def, work_dir, new_state)) {
+      if (!LCH_TableStoreNewState(table_def, work_dir, pretty_print,
+                                  new_state)) {
         LCH_LOG_ERROR("Failed to store new state for table '%s'.", table_id);
         LCH_JsonDestroy(new_state);
         LCH_JsonDestroy(deltas);
@@ -215,7 +218,7 @@ static bool Commit(const LCH_Instance *const instance) {
     return false;
   }
 
-  if (!LCH_BlockStore(work_dir, block)) {
+  if (!LCH_BlockStore(instance, block)) {
     LCH_LOG_ERROR("Failed to store block.");
     LCH_JsonDestroy(block);
     return false;
@@ -408,6 +411,8 @@ char *LCH_Diff(const char *const work_dir, const char *const final_id,
     return NULL;
   }
 
+  const bool pretty_print = LCH_InstancePrettyPrint(instance);
+
   char *const block_id = LCH_HeadGet("HEAD", work_dir);
   if (block_id == NULL) {
     LCH_LOG_ERROR(
@@ -450,7 +455,7 @@ char *LCH_Diff(const char *const work_dir, const char *const final_id,
     return NULL;
   }
 
-  LCH_Buffer *buffer = LCH_JsonCompose(patch, false);
+  LCH_Buffer *buffer = LCH_JsonCompose(patch, pretty_print);
   LCH_JsonDestroy(patch);
   if (buffer == NULL) {
     LCH_LOG_ERROR("Failed to compose patch into JSON");
@@ -470,6 +475,8 @@ char *LCH_Rebase(const char *const work_dir, size_t *const buf_len) {
     LCH_LOG_ERROR("Failed to load instance from configuration file");
     return NULL;
   }
+
+  const bool pretty_print = LCH_InstancePrettyPrint(instance);
 
   const LCH_List *const table_defs = LCH_InstanceGetTables(instance);
   size_t n_tables = LCH_ListLength(table_defs);
@@ -576,7 +583,7 @@ char *LCH_Rebase(const char *const work_dir, size_t *const buf_len) {
     return NULL;
   }
 
-  LCH_Buffer *const buffer = LCH_JsonCompose(patch, false);
+  LCH_Buffer *const buffer = LCH_JsonCompose(patch, pretty_print);
   LCH_JsonDestroy(patch);
   if (buffer == NULL) {
     LCH_LOG_ERROR("Failed to compose patch into JSON");

--- a/lib/leech.c
+++ b/lib/leech.c
@@ -450,7 +450,7 @@ char *LCH_Diff(const char *const work_dir, const char *const final_id,
     return NULL;
   }
 
-  LCH_Buffer *buffer = LCH_JsonCompose(patch);
+  LCH_Buffer *buffer = LCH_JsonCompose(patch, false);
   LCH_JsonDestroy(patch);
   if (buffer == NULL) {
     LCH_LOG_ERROR("Failed to compose patch into JSON");
@@ -576,7 +576,7 @@ char *LCH_Rebase(const char *const work_dir, size_t *const buf_len) {
     return NULL;
   }
 
-  LCH_Buffer *const buffer = LCH_JsonCompose(patch);
+  LCH_Buffer *const buffer = LCH_JsonCompose(patch, false);
   LCH_JsonDestroy(patch);
   if (buffer == NULL) {
     LCH_LOG_ERROR("Failed to compose patch into JSON");

--- a/lib/table.c
+++ b/lib/table.c
@@ -601,7 +601,7 @@ bool LCH_TableStoreNewState(const LCH_TableInfo *const self,
     return false;
   }
 
-  return LCH_JsonComposeFile(state, path);
+  return LCH_JsonComposeFile(state, path, false);
 }
 
 static LCH_List *ConcatenateFields(const LCH_List *const left,

--- a/lib/table.c
+++ b/lib/table.c
@@ -593,7 +593,7 @@ LCH_Json *LCH_TableInfoLoadOldState(const LCH_TableInfo *const table_info,
 }
 
 bool LCH_TableStoreNewState(const LCH_TableInfo *const self,
-                            const char *const work_dir,
+                            const char *const work_dir, const bool pretty_print,
                             const LCH_Json *const state) {
   char path[PATH_MAX];
   if (!LCH_PathJoin(path, sizeof(path), 3, work_dir, "snapshot",
@@ -601,7 +601,7 @@ bool LCH_TableStoreNewState(const LCH_TableInfo *const self,
     return false;
   }
 
-  return LCH_JsonComposeFile(state, path, false);
+  return LCH_JsonComposeFile(state, path, pretty_print);
 }
 
 static LCH_List *ConcatenateFields(const LCH_List *const left,

--- a/lib/table.h
+++ b/lib/table.h
@@ -21,7 +21,8 @@ LCH_Json *LCH_TableInfoLoadOldState(const LCH_TableInfo *table_info,
                                     const char *work_dir);
 
 bool LCH_TableStoreNewState(const LCH_TableInfo *table_info,
-                            const char *work_dir, const LCH_Json *new_state);
+                            const char *work_dir, bool pretty_print,
+                            const LCH_Json *new_state);
 
 bool LCH_TablePatch(const LCH_TableInfo *table_info, const char *type,
                     const char *field, const char *value,

--- a/tests/acceptance.py
+++ b/tests/acceptance.py
@@ -16,6 +16,7 @@ PSQL_PARAMS = "dbname=leech"
 
 LEECH_CONFIG = {
     "version": "0.1.0",
+    "pretty_print": True,
     "tables": {
         "CLD": {
             "primary_fields": ["name"],

--- a/tests/check_json.c
+++ b/tests/check_json.c
@@ -757,7 +757,7 @@ START_TEST(test_LCH_JsonComposeString) {
     LCH_Json *const json = LCH_JsonStringCreate(str);
     ck_assert_ptr_nonnull(json);
 
-    LCH_Buffer *const actual = LCH_JsonCompose(json);
+    LCH_Buffer *const actual = LCH_JsonCompose(json, false);
     ck_assert_ptr_nonnull(actual);
 
     ck_assert_str_eq(LCH_BufferData(actual), expected[i]);
@@ -778,7 +778,7 @@ START_TEST(test_LCH_JsonComposeObject) {
     LCH_Json *const json = LCH_JsonObjectCreate();
     ck_assert_ptr_nonnull(json);
 
-    LCH_Buffer *const actual = LCH_JsonCompose(json);
+    LCH_Buffer *const actual = LCH_JsonCompose(json, false);
     ck_assert_ptr_nonnull(json);
 
     ck_assert_str_eq(LCH_BufferData(actual), "{}");
@@ -800,7 +800,7 @@ START_TEST(test_LCH_JsonComposeObject) {
 
     ck_assert(LCH_JsonObjectSet(parent, key, child));
 
-    LCH_Buffer *const actual = LCH_JsonCompose(parent);
+    LCH_Buffer *const actual = LCH_JsonCompose(parent, false);
     ck_assert_ptr_nonnull(parent);
 
     ck_assert_str_eq(LCH_BufferData(actual), "{\"foo\":\"bar\"}");
@@ -822,7 +822,7 @@ START_TEST(test_LCH_JsonComposeObject) {
 
     ck_assert(LCH_JsonObjectSet(parent, key, child));
 
-    LCH_Buffer *const actual = LCH_JsonCompose(parent);
+    LCH_Buffer *const actual = LCH_JsonCompose(parent, false);
     ck_assert_ptr_nonnull(parent);
 
     ck_assert_str_eq(LCH_BufferData(actual), "{\"foo\":\"bar\\\"baz\\\"\"}");
@@ -844,7 +844,7 @@ START_TEST(test_LCH_JsonComposeObject) {
 
     ck_assert(LCH_JsonObjectSet(parent, key, child));
 
-    LCH_Buffer *const actual = LCH_JsonCompose(parent);
+    LCH_Buffer *const actual = LCH_JsonCompose(parent, false);
     ck_assert_ptr_nonnull(parent);
 
     ck_assert_str_eq(LCH_BufferData(actual), "{\"foo\\\"bar\\\"\":\"baz\"}");

--- a/tests/check_json.c
+++ b/tests/check_json.c
@@ -716,146 +716,271 @@ START_TEST(test_LCH_JsonParseFile) {
 END_TEST
 
 START_TEST(test_LCH_JsonComposeNull) {
-  // TODO: Implement
+  LCH_Json *const json = LCH_JsonNullCreate();
+  ck_assert_ptr_nonnull(json);
+  {
+    LCH_Buffer *const buffer = LCH_JsonCompose(json, false);
+    ck_assert_ptr_nonnull(buffer);
+
+    ck_assert_str_eq(LCH_BufferData(buffer), "null");
+    LCH_BufferDestroy(buffer);
+  }
+  {
+    LCH_Buffer *const buffer = LCH_JsonCompose(json, true);
+    ck_assert_ptr_nonnull(buffer);
+
+    ck_assert_str_eq(LCH_BufferData(buffer), "null\n");
+    LCH_BufferDestroy(buffer);
+  }
+  LCH_JsonDestroy(json);
 }
 END_TEST
 
 START_TEST(test_LCH_JsonComposeTrue) {
-  // TODO: Implement
+  LCH_Json *const json = LCH_JsonTrueCreate();
+  ck_assert_ptr_nonnull(json);
+  {
+    LCH_Buffer *const buffer = LCH_JsonCompose(json, false);
+    ck_assert_ptr_nonnull(buffer);
+
+    ck_assert_str_eq(LCH_BufferData(buffer), "true");
+    LCH_BufferDestroy(buffer);
+  }
+  {
+    LCH_Buffer *const buffer = LCH_JsonCompose(json, true);
+    ck_assert_ptr_nonnull(buffer);
+
+    ck_assert_str_eq(LCH_BufferData(buffer), "true\n");
+    LCH_BufferDestroy(buffer);
+  }
+  LCH_JsonDestroy(json);
 }
 END_TEST
 
 START_TEST(test_LCH_JsonComposeFalse) {
-  // TODO: Implement
+  LCH_Json *const json = LCH_JsonFalseCreate();
+  ck_assert_ptr_nonnull(json);
+  {
+    LCH_Buffer *const buffer = LCH_JsonCompose(json, false);
+    ck_assert_ptr_nonnull(buffer);
+
+    ck_assert_str_eq(LCH_BufferData(buffer), "false");
+    LCH_BufferDestroy(buffer);
+  }
+  {
+    LCH_Buffer *const buffer = LCH_JsonCompose(json, true);
+    ck_assert_ptr_nonnull(buffer);
+
+    ck_assert_str_eq(LCH_BufferData(buffer), "false\n");
+    LCH_BufferDestroy(buffer);
+  }
+  LCH_JsonDestroy(json);
 }
 END_TEST
 
 START_TEST(test_LCH_JsonComposeNumber) {
-  // TODO: Implement
+  LCH_Json *const json = LCH_JsonNumberCreate(123.0);
+  ck_assert_ptr_nonnull(json);
+  {
+    LCH_Buffer *const actual = LCH_JsonCompose(json, false);
+    ck_assert_ptr_nonnull(actual);
+
+    ck_assert_str_eq(LCH_BufferData(actual), "123.000000");
+    LCH_BufferDestroy(actual);
+  }
+  {
+    LCH_Buffer *const actual = LCH_JsonCompose(json, true);
+    ck_assert_ptr_nonnull(actual);
+
+    ck_assert_str_eq(LCH_BufferData(actual), "123.000000\n");
+    LCH_BufferDestroy(actual);
+  }
+  LCH_JsonDestroy(json);
 }
 END_TEST
 
 START_TEST(test_LCH_JsonComposeString) {
-  const char *const strs[] = {
-      "foo",
-      "\"bar\"",
-      " \" baz \" ",
-  };
-  const char *const expected[] = {
-      "\"foo\"",
-      "\"\\\"bar\\\"\"",
-      "\" \\\" baz \\\" \"",
-  };
-
-  const size_t num_strs = sizeof(strs) / sizeof(char *);
-  ck_assert_int_eq(num_strs, sizeof(expected) / sizeof(char *));
-
-  for (size_t i = 0; i < num_strs; i++) {
-    LCH_Buffer *const str = LCH_BufferFromString(strs[i]);
+  {
+    LCH_Buffer *const str = LCH_BufferFromString("foo");
     ck_assert_ptr_nonnull(str);
 
     LCH_Json *const json = LCH_JsonStringCreate(str);
     ck_assert_ptr_nonnull(json);
 
-    LCH_Buffer *const actual = LCH_JsonCompose(json, false);
-    ck_assert_ptr_nonnull(actual);
+    {
+      LCH_Buffer *const actual = LCH_JsonCompose(json, false);
+      ck_assert_ptr_nonnull(actual);
 
-    ck_assert_str_eq(LCH_BufferData(actual), expected[i]);
+      ck_assert_str_eq(LCH_BufferData(actual), "\"foo\"");
+      LCH_BufferDestroy(actual);
+    }
+    {
+      LCH_Buffer *const actual = LCH_JsonCompose(json, true);
+      ck_assert_ptr_nonnull(actual);
+
+      ck_assert_str_eq(LCH_BufferData(actual), "\"foo\"\n");
+      LCH_BufferDestroy(actual);
+    }
 
     LCH_JsonDestroy(json);
-    LCH_BufferDestroy(actual);
+  }
+  {
+    LCH_Buffer *const str = LCH_BufferFromString("\"bar\"");
+    ck_assert_ptr_nonnull(str);
+
+    LCH_Json *const json = LCH_JsonStringCreate(str);
+    ck_assert_ptr_nonnull(json);
+
+    {
+      LCH_Buffer *const actual = LCH_JsonCompose(json, false);
+      ck_assert_ptr_nonnull(actual);
+
+      ck_assert_str_eq(LCH_BufferData(actual), "\"\\\"bar\\\"\"");
+      LCH_BufferDestroy(actual);
+    }
+    {
+      LCH_Buffer *const actual = LCH_JsonCompose(json, true);
+      ck_assert_ptr_nonnull(actual);
+
+      ck_assert_str_eq(LCH_BufferData(actual), "\"\\\"bar\\\"\"\n");
+      LCH_BufferDestroy(actual);
+    }
+
+    LCH_JsonDestroy(json);
   }
 }
 END_TEST
 
 START_TEST(test_LCH_JsonComposeArray) {
-  // TODO: Implement
+  LCH_Json *const json = LCH_JsonArrayCreate();
+  ck_assert_ptr_nonnull(json);
+  {
+    LCH_Buffer *const actual = LCH_JsonCompose(json, false);
+    ck_assert_ptr_nonnull(actual);
+
+    ck_assert_str_eq(LCH_BufferData(actual), "[]");
+    LCH_BufferDestroy(actual);
+  }
+  {
+    LCH_Buffer *const actual = LCH_JsonCompose(json, true);
+    ck_assert_ptr_nonnull(actual);
+
+    ck_assert_str_eq(LCH_BufferData(actual), "[\n]\n");
+    LCH_BufferDestroy(actual);
+  }
+  LCH_JsonDestroy(json);
 }
 END_TEST
 
 START_TEST(test_LCH_JsonComposeObject) {
+  LCH_Json *const json = LCH_JsonObjectCreate();
+  ck_assert_ptr_nonnull(json);
   {
-    LCH_Json *const json = LCH_JsonObjectCreate();
-    ck_assert_ptr_nonnull(json);
-
     LCH_Buffer *const actual = LCH_JsonCompose(json, false);
     ck_assert_ptr_nonnull(json);
 
     ck_assert_str_eq(LCH_BufferData(actual), "{}");
     LCH_BufferDestroy(actual);
-    LCH_JsonDestroy(json);
   }
   {
-    LCH_Json *const parent = LCH_JsonObjectCreate();
-    ck_assert_ptr_nonnull(parent);
+    LCH_Buffer *const actual = LCH_JsonCompose(json, true);
+    ck_assert_ptr_nonnull(json);
 
-    LCH_Buffer *const value = LCH_BufferFromString("bar");
-    ck_assert_ptr_nonnull(value);
-
-    LCH_Json *const child = LCH_JsonStringCreate(value);
-    ck_assert_ptr_nonnull(child);
-
-    const LCH_Buffer *const key = LCH_BufferStaticFromString("foo");
-    ck_assert_ptr_nonnull(key);
-
-    ck_assert(LCH_JsonObjectSet(parent, key, child));
-
-    LCH_Buffer *const actual = LCH_JsonCompose(parent, false);
-    ck_assert_ptr_nonnull(parent);
-
-    ck_assert_str_eq(LCH_BufferData(actual), "{\"foo\":\"bar\"}");
+    ck_assert_str_eq(LCH_BufferData(actual), "{\n}\n");
     LCH_BufferDestroy(actual);
-    LCH_JsonDestroy(parent);
   }
-  {
-    LCH_Json *const parent = LCH_JsonObjectCreate();
-    ck_assert_ptr_nonnull(parent);
-
-    LCH_Buffer *const value = LCH_BufferFromString("bar\"baz\"");
-    ck_assert_ptr_nonnull(value);
-
-    LCH_Json *const child = LCH_JsonStringCreate(value);
-    ck_assert_ptr_nonnull(child);
-
-    const LCH_Buffer *const key = LCH_BufferStaticFromString("foo");
-    ck_assert_ptr_nonnull(key);
-
-    ck_assert(LCH_JsonObjectSet(parent, key, child));
-
-    LCH_Buffer *const actual = LCH_JsonCompose(parent, false);
-    ck_assert_ptr_nonnull(parent);
-
-    ck_assert_str_eq(LCH_BufferData(actual), "{\"foo\":\"bar\\\"baz\\\"\"}");
-    LCH_BufferDestroy(actual);
-    LCH_JsonDestroy(parent);
-  }
-  {
-    LCH_Json *const parent = LCH_JsonObjectCreate();
-    ck_assert_ptr_nonnull(parent);
-
-    LCH_Buffer *const value = LCH_BufferFromString("baz");
-    ck_assert_ptr_nonnull(value);
-
-    LCH_Json *const child = LCH_JsonStringCreate(value);
-    ck_assert_ptr_nonnull(child);
-
-    const LCH_Buffer *const key = LCH_BufferStaticFromString("foo\"bar\"");
-    ck_assert_ptr_nonnull(key);
-
-    ck_assert(LCH_JsonObjectSet(parent, key, child));
-
-    LCH_Buffer *const actual = LCH_JsonCompose(parent, false);
-    ck_assert_ptr_nonnull(parent);
-
-    ck_assert_str_eq(LCH_BufferData(actual), "{\"foo\\\"bar\\\"\":\"baz\"}");
-    LCH_BufferDestroy(actual);
-    LCH_JsonDestroy(parent);
-  }
+  LCH_JsonDestroy(json);
 }
 END_TEST
 
 START_TEST(test_LCH_JsonCompose) {
-  // TODO: Implement
+  LCH_Json *const config = LCH_JsonObjectCreate();
+  ck_assert_ptr_nonnull(config);
+
+  LCH_Buffer *const version = LCH_BufferFromString(PACKAGE_VERSION);
+  ck_assert_ptr_nonnull(version);
+  ck_assert(LCH_JsonObjectSetString(
+      config, LCH_BufferStaticFromString("version"), version));
+
+  const double max_chain_length = 64.0;
+  ck_assert(LCH_JsonObjectSetNumber(
+      config, LCH_BufferStaticFromString("max_chain_length"), 64.0));
+
+  LCH_Json *const pretty_json = LCH_JsonTrueCreate();
+  ck_assert_ptr_nonnull(pretty_json);
+  ck_assert(LCH_JsonObjectSet(config, LCH_BufferStaticFromString("pretty_json"),
+                              pretty_json));
+
+  LCH_Json *const compression = LCH_JsonFalseCreate();
+  ck_assert_ptr_nonnull(compression);
+  ck_assert(LCH_JsonObjectSet(config, LCH_BufferStaticFromString("compression"),
+                              compression));
+
+  LCH_Json *const tables = LCH_JsonObjectCreate();
+  ck_assert_ptr_nonnull(tables);
+  ck_assert(
+      LCH_JsonObjectSet(config, LCH_BufferStaticFromString("tables"), tables));
+
+  LCH_Json *const beatles = LCH_JsonObjectCreate();
+  ck_assert_ptr_nonnull(beatles);
+  ck_assert(
+      LCH_JsonObjectSet(tables, LCH_BufferStaticFromString("BTL"), beatles));
+
+  LCH_Json *const primary_fields = LCH_JsonArrayCreate();
+  ck_assert_ptr_nonnull(primary_fields);
+  ck_assert(LCH_JsonObjectSet(
+      beatles, LCH_BufferStaticFromString("primary_fields"), primary_fields));
+
+  LCH_Buffer *const first_name_buffer = LCH_BufferFromString("first_name");
+  ck_assert_ptr_nonnull(first_name_buffer);
+  LCH_Json *const first_name = LCH_JsonStringCreate(first_name_buffer);
+  ck_assert_ptr_nonnull(first_name);
+  ck_assert(LCH_JsonArrayAppend(primary_fields, first_name));
+
+  LCH_Buffer *const last_name_buffer = LCH_BufferFromString("last_name");
+  ck_assert_ptr_nonnull(last_name_buffer);
+  LCH_Json *const last_name = LCH_JsonStringCreate(last_name_buffer);
+  ck_assert_ptr_nonnull(last_name);
+  ck_assert(LCH_JsonArrayAppend(primary_fields, last_name));
+
+  LCH_Buffer *const born_buffer = LCH_BufferFromString("born");
+  ck_assert_ptr_nonnull(born_buffer);
+  LCH_Json *const born = LCH_JsonStringCreate(born_buffer);
+  ck_assert_ptr_nonnull(born);
+  ck_assert(LCH_JsonArrayAppend(primary_fields, born));
+
+  LCH_Json *const subsidiary_fields = LCH_JsonNullCreate();
+  ck_assert_ptr_nonnull(subsidiary_fields);
+  ck_assert(LCH_JsonObjectSet(beatles,
+                              LCH_BufferStaticFromString("subsidiary_fields"),
+                              subsidiary_fields));
+
+  LCH_Buffer *const actual = LCH_JsonCompose(config, true);
+  ck_assert_ptr_nonnull(actual);
+
+  const char *const expected =
+      "{\n"
+      "  \"version\": \"" PACKAGE_VERSION
+      "\",\n"
+      "  \"compression\": false,\n"
+      "  \"tables\": {\n"
+      "    \"BTL\": {\n"
+      "      \"subsidiary_fields\": null,\n"
+      "      \"primary_fields\": [\n"
+      "        \"first_name\",\n"
+      "        \"last_name\",\n"
+      "        \"born\"\n"
+      "      ]\n"
+      "    }\n"
+      "  },\n"
+      "  \"pretty_json\": true,\n"
+      "  \"max_chain_length\": 64.000000\n"
+      "}\n";
+
+  ck_assert_str_eq(LCH_BufferData(actual), expected);
+  LCH_BufferDestroy(actual);
+
+  LCH_JsonDestroy(config);
 }
 END_TEST
 
@@ -1117,12 +1242,12 @@ Suite *JSONSuite(void) {
   }
   {
     TCase *tc = tcase_create("LCH_JsonComposeArray");
-    tcase_add_test(tc, test_LCH_JsonCompose);
+    tcase_add_test(tc, test_LCH_JsonComposeArray);
     suite_add_tcase(s, tc);
   }
   {
     TCase *tc = tcase_create("LCH_JsonComposeObject");
-    tcase_add_test(tc, test_LCH_JsonCompose);
+    tcase_add_test(tc, test_LCH_JsonComposeObject);
     suite_add_tcase(s, tc);
   }
   {


### PR DESCRIPTION
- **Implemented pretty option for JSON composer**
- **Added unit tests for JSON composer**
- **Added pretty print option to leech config**
- **Fixed typo in max chain length getter**
- **Now pretty prints if option is set in config**
