### PR TITLE
 CFE-4379: Now checks versions in patches and blocks before interpreting them

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -67,10 +67,9 @@ AC_MSG_CHECKING([for debug option])
 if test x"$debug" = x"yes"
 then
     AC_MSG_RESULT(yes)
-    CFLAGS="$CFLAGS -g3 -O0"
 else
     AC_MSG_RESULT(no)
-    CFLAGS="$CFLAGS -O2 -DNDEBUG"
+    CFLAGS="$CFLAGS -DNDEBUG"
 fi
 
 AC_CONFIG_FILES([Makefile lib/Makefile bin/Makefile tests/Makefile])

--- a/lib/block.c
+++ b/lib/block.c
@@ -21,26 +21,22 @@ LCH_Json *LCH_BlockCreate(const char *const parent_id,
     return NULL;
   }
 
-  LCH_Buffer *const version = LCH_BufferFromString(PACKAGE_VERSION);
-  if (version == NULL) {
-    LCH_JsonDestroy(block);
-    return NULL;
+  {
+    const LCH_Buffer *const key = LCH_BufferStaticFromString("version");
+    if (!LCH_JsonObjectSetNumber(block, key, (double)LCH_BLOCK_VERSION)) {
+      LCH_JsonDestroy(block);
+      return NULL;
+    }
   }
 
-  if (!LCH_JsonObjectSetString(block, LCH_BufferStaticFromString("version"),
-                               version)) {
-    LCH_LOG_ERROR("Failed to set version field in block");
-    LCH_BufferDestroy(version);
-    LCH_JsonDestroy(block);
-    return NULL;
-  }
-
-  const double timestamp = (double)time(NULL);
-  if (!LCH_JsonObjectSetNumber(block, LCH_BufferStaticFromString("timestamp"),
-                               timestamp)) {
-    LCH_LOG_ERROR("Failed to set timestamp field in block");
-    LCH_JsonDestroy(block);
-    return NULL;
+  {
+    const time_t timestamp = time(NULL);
+    const LCH_Buffer *const key = LCH_BufferStaticFromString("timestamp");
+    if (!LCH_JsonObjectSetNumber(block, key, (double)timestamp)) {
+      LCH_LOG_ERROR("Failed to set timestamp field in block");
+      LCH_JsonDestroy(block);
+      return NULL;
+    }
   }
 
   LCH_Buffer *const parent = LCH_BufferFromString(parent_id);

--- a/lib/block.h
+++ b/lib/block.h
@@ -9,6 +9,7 @@
 LCH_Json *LCH_BlockCreate(const char *parent_id, LCH_Json *const payload);
 bool LCH_BlockStore(const LCH_Instance *const instance, const LCH_Json *block);
 LCH_Json *LCH_BlockLoad(const char *work_dir, const char *block_id);
+bool LCH_BlockGetVersion(const LCH_Json *patch, size_t *version);
 const char *LCH_BlockGetParentId(const LCH_Json *block);
 bool LCH_BlockIsGenisisId(const char *block_id);
 const LCH_Json *LCH_BlockGetPayload(const LCH_Json *block);

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -107,11 +107,8 @@ bool LCH_BufferPrintFormat(LCH_Buffer *const self, const char *const format,
   }
 
   va_start(ap, format);
-  const int ret = vsnprintf(self->buffer + self->length,
-                            self->capacity - self->length, format, ap);
-#ifdef NDEBUG
-  LCH_UNUSED(ret);
-#endif  // NDEBUG
+  LCH_NDEBUG_UNUSED const int ret = vsnprintf(
+      self->buffer + self->length, self->capacity - self->length, format, ap);
   assert(length >= 0);
   va_end(ap);
   if (length < 0) {

--- a/lib/definitions.h
+++ b/lib/definitions.h
@@ -1,6 +1,8 @@
 #ifndef _LEECH_DEFINITIONS_H
 #define _LEECH_DEFINITIONS_H
 
+#define LCH_PATCH_VERSION 1
+
 #define LCH_KIBIBYTE(n) (n * 1024UL)
 #define LCH_MEBIBYTE(n) (n * 1024UL * 1024UL)
 #define LCH_GIBIBYTE(n) (n * 1024ULL * 1024ULL * 1024ULL)

--- a/lib/definitions.h
+++ b/lib/definitions.h
@@ -14,7 +14,12 @@
 #define LCH_MIN(a, b) ((a < b) ? a : b)
 #define LCH_MAX(a, b) ((a > b) ? a : b)
 
-#define LCH_UNUSED(x) (void)x
+#define LCH_UNUSED __attribute__((unused))
+#ifdef NDEBUG
+#define LCH_NDEBUG_UNUSED __attribute__((unused))
+#else
+#define LCH_NDEBUG_UNUSED
+#endif
 
 #ifdef _WIN32
 #define LCH_PATH_SEP '\\'

--- a/lib/definitions.h
+++ b/lib/definitions.h
@@ -2,6 +2,7 @@
 #define _LEECH_DEFINITIONS_H
 
 #define LCH_PATCH_VERSION 1
+#define LCH_BLOCK_VERSION 1
 
 #define LCH_KIBIBYTE(n) (n * 1024UL)
 #define LCH_MEBIBYTE(n) (n * 1024UL * 1024UL)

--- a/lib/json.c
+++ b/lib/json.c
@@ -1358,81 +1358,74 @@ static LCH_Buffer *BufferParseString(LCH_JsonParser *const parser) {
             return NULL;
           }
           break;
-
         case '\\':
           if (!LCH_BufferAppend(str, '\\')) {
             LCH_BufferDestroy(str);
             return NULL;
           }
           break;
-
+        /* This could modify binary strings
         case '/':
           if (!LCH_BufferAppend(str, '/')) {
             LCH_BufferDestroy(str);
             return NULL;
           }
           break;
-
         case 'b':
           if (!LCH_BufferAppend(str, '\b')) {
             LCH_BufferDestroy(str);
             return NULL;
           }
           break;
-
         case 'f':
           if (!LCH_BufferAppend(str, '\f')) {
             LCH_BufferDestroy(str);
             return NULL;
           }
           break;
-
         case 'n':
           if (!LCH_BufferAppend(str, '\n')) {
             LCH_BufferDestroy(str);
             return NULL;
           }
           break;
-
         case 'r':
           if (!LCH_BufferAppend(str, '\r')) {
             LCH_BufferDestroy(str);
             return NULL;
           }
           break;
-
         case 't':
           if (!LCH_BufferAppend(str, '\t')) {
             LCH_BufferDestroy(str);
             return NULL;
           }
           break;
-
-          /* Cannot have this is we want to support binary data in strings */
-          // case 'u':
-          //   if (parser->cursor + 6 > parser->end) {
-          //     LCH_LOG_ERROR(
-          //         "Failed to parse JSON: "
-          //         "Expected uncode control sequence after '\\u', "
-          //         "but reached End-of-Buffer");
-          //     LCH_BufferDestroy(str);
-          //     return NULL;
-          //   }
-          //   if (!LCH_BufferUnicodeToUTF8(str, parser->cursor + 2)) {
-          //     LCH_BufferDestroy(str);
-          //     return NULL;
-          //   }
-          //   parser->cursor += 4;
-          //   break;
-
+        case 'u':
+          if (parser->cursor + 6 > parser->end) {
+            LCH_LOG_ERROR(
+                "Failed to parse JSON: "
+                "Expected uncode control sequence after '\\u', "
+                "but reached End-of-Buffer");
+            LCH_BufferDestroy(str);
+            return NULL;
+          }
+          if (!LCH_BufferUnicodeToUTF8(str, parser->cursor + 2)) {
+            LCH_BufferDestroy(str);
+            return NULL;
+          }
+          parser->cursor += 4;
+          break;
+        */
         default:
-          /* Same reason as above */
-          // LCH_LOG_ERROR(
-          //     "Failed to parse JSON string: "
-          //     "Illegal control character '\\%c'",
-          //     parser->cursor[0]);
-          // LCH_BufferDestroy(str);
-          // return NULL;
+          /* Same reason as above
+          LCH_LOG_ERROR(
+              "Failed to parse JSON string: "
+              "Illegal control character '\\%c'",
+              parser->cursor[0]);
+          LCH_BufferDestroy(str);
+          return NULL;
+          */
           if (!LCH_BufferAppend(str, parser->cursor[1])) {
             LCH_BufferDestroy(str);
             return NULL;
@@ -1797,6 +1790,7 @@ static bool StringComposeString(const LCH_Buffer *const str,
       case '\\':
         control_sequence = "\\\\";
         break;
+      /* This could modify binary strings!
       case '\b':
         control_sequence = "\\b";
         break;
@@ -1812,6 +1806,7 @@ static bool StringComposeString(const LCH_Buffer *const str,
       case '\t':
         control_sequence = "\\t";
         break;
+      */
       default:
         if (!LCH_BufferAppend(buffer, data[i])) {
           return false;

--- a/lib/json.c
+++ b/lib/json.c
@@ -1276,11 +1276,8 @@ static LCH_Json *ParseNull(LCH_JsonParser *const parser) {
   assert(parser->cursor != NULL);
   assert(parser->end != NULL);
 
-  const bool success = ParseToken(parser, "null");
+  LCH_NDEBUG_UNUSED const bool success = ParseToken(parser, "null");
   assert(success);
-#ifdef NDEBUG
-  LCH_UNUSED(success);
-#endif  // NDEBUG
 
   LCH_Json *const json = LCH_JsonNullCreate();
   if (json == NULL) {
@@ -1294,11 +1291,8 @@ static LCH_Json *ParseTrue(LCH_JsonParser *const parser) {
   assert(parser->cursor != NULL);
   assert(parser->end != NULL);
 
-  const bool success = ParseToken(parser, "true");
+  LCH_NDEBUG_UNUSED const bool success = ParseToken(parser, "true");
   assert(success);
-#ifdef NDEBUG
-  LCH_UNUSED(success);
-#endif  // NDEBUG
 
   LCH_Json *const json = LCH_JsonTrueCreate();
   if (json == NULL) {
@@ -1312,11 +1306,8 @@ static LCH_Json *ParseFalse(LCH_JsonParser *const parser) {
   assert(parser->cursor != NULL);
   assert(parser->end != NULL);
 
-  const bool success = ParseToken(parser, "false");
+  LCH_NDEBUG_UNUSED const bool success = ParseToken(parser, "false");
   assert(success);
-#ifdef NDEBUG
-  LCH_UNUSED(success);
-#endif  // NDEBUG
 
   LCH_Json *const json = LCH_JsonFalseCreate();
   if (json == NULL) {
@@ -1330,11 +1321,8 @@ static LCH_Buffer *BufferParseString(LCH_JsonParser *const parser) {
   assert(parser->cursor != NULL);
   assert(parser->end != NULL);
 
-  const bool success = ParseToken(parser, "\"");
+  LCH_NDEBUG_UNUSED const bool success = ParseToken(parser, "\"");
   assert(success);
-#ifdef NDEBUG
-  LCH_UNUSED(success);
-#endif  // NDEBUG
 
   LCH_Buffer *const str = LCH_BufferCreate();
   if (str == NULL) {
@@ -1476,11 +1464,8 @@ static LCH_Json *ParseObject(LCH_JsonParser *const parser) {
     return NULL;
   }
 
-  bool success = ParseToken(parser, "{");
+  LCH_NDEBUG_UNUSED const bool success = ParseToken(parser, "{");
   assert(success);
-#ifdef NDEBUG
-  LCH_UNUSED(success);
-#endif  // NDEBUG
 
   TrimLeadingWhitespace(parser);
 
@@ -1544,11 +1529,8 @@ static LCH_Json *ParseArray(LCH_JsonParser *const parser) {
     return NULL;
   }
 
-  const bool success = ParseToken(parser, "[");
+  LCH_NDEBUG_UNUSED const bool success = ParseToken(parser, "[");
   assert(success);
-#ifdef NDEBUG
-  LCH_UNUSED(success);
-#endif  // NDEBUG
 
   TrimLeadingWhitespace(parser);
 
@@ -1725,14 +1707,11 @@ LCH_Json *LCH_JsonParseFile(const char *const filename) {
 static bool Compose(const LCH_Json *const json, LCH_Buffer *const buffer,
                     bool pretty, size_t indent);
 
-static bool ComposeNull(const LCH_Json *const json, LCH_Buffer *const buffer) {
+static bool ComposeNull(LCH_NDEBUG_UNUSED const LCH_Json *const json,
+                        LCH_Buffer *const buffer) {
   assert(json != NULL);
   assert(buffer != NULL);
   assert(LCH_JsonGetType(json) == LCH_JSON_TYPE_NULL);
-
-#ifdef NDEBUG
-  LCH_UNUSED(json);
-#endif  // NDEBUG
 
   if (!LCH_BufferPrintFormat(buffer, "null")) {
     return false;
@@ -1740,14 +1719,11 @@ static bool ComposeNull(const LCH_Json *const json, LCH_Buffer *const buffer) {
   return true;
 }
 
-static bool ComposeTrue(const LCH_Json *const json, LCH_Buffer *const buffer) {
+static bool ComposeTrue(LCH_NDEBUG_UNUSED const LCH_Json *const json,
+                        LCH_Buffer *const buffer) {
   assert(json != NULL);
   assert(buffer != NULL);
   assert(LCH_JsonGetType(json) == LCH_JSON_TYPE_TRUE);
-
-#ifdef NDEBUG
-  LCH_UNUSED(json);
-#endif  // NDEBUG
 
   if (!LCH_BufferPrintFormat(buffer, "true")) {
     return false;
@@ -1755,14 +1731,11 @@ static bool ComposeTrue(const LCH_Json *const json, LCH_Buffer *const buffer) {
   return true;
 }
 
-static bool ComposeFalse(const LCH_Json *const json, LCH_Buffer *const buffer) {
+static bool ComposeFalse(LCH_NDEBUG_UNUSED const LCH_Json *const json,
+                         LCH_Buffer *const buffer) {
   assert(json != NULL);
   assert(buffer != NULL);
   assert(LCH_JsonGetType(json) == LCH_JSON_TYPE_FALSE);
-
-#ifdef NDEBUG
-  LCH_UNUSED(json);
-#endif  // NDEBUG
 
   if (!LCH_BufferPrintFormat(buffer, "false")) {
     return false;

--- a/lib/json.c
+++ b/lib/json.c
@@ -1851,6 +1851,24 @@ static bool ComposeNumber(const LCH_Json *const json,
   if (!LCH_BufferPrintFormat(buffer, "%f", json->number)) {
     return false;
   }
+
+  // Remove trailing zeroes
+  size_t length = LCH_BufferLength(buffer);
+  for (size_t i = 1; i < length; i++) {
+    const char *const data = LCH_BufferData(buffer);
+    if (data[length - i] != '0') {
+      break;
+    }
+    LCH_BufferChop(buffer, length - i);
+  }
+
+  // Remove trailing dot
+  length = LCH_BufferLength(buffer);
+  const char *const data = LCH_BufferData(buffer);
+  if (data[length - 1] == '.') {
+    LCH_BufferChop(buffer, length - 1);
+  }
+
   return true;
 }
 

--- a/lib/leech.c
+++ b/lib/leech.c
@@ -1002,9 +1002,9 @@ static bool Patch(const LCH_Instance *const instance, const char *const field,
                   const size_t size) {
   const char *const work_dir = LCH_InstanceGetWorkDirectory(instance);
 
-  LCH_Json *const patch = LCH_JsonParse(buffer, size);
+  LCH_Json *const patch = LCH_PatchParse(buffer, size);
   if (patch == NULL) {
-    LCH_LOG_ERROR("Failed to parse patch");
+    LCH_LOG_ERROR("Failed to interpret patch");
     return false;
   }
 

--- a/lib/leech_csv.c
+++ b/lib/leech_csv.c
@@ -163,7 +163,7 @@ bool LCH_CallbackTruncateTable(void *const _conn, const char *const table_name,
 }
 
 LCH_List *LCH_CallbackGetTable(void *const _conn, const char *const table_name,
-                               const LCH_List *const columns) {
+                               LCH_UNUSED const LCH_List *const columns) {
   CSVconn *const conn = (CSVconn *)_conn;
   assert(conn != NULL);
   assert(conn->filename != NULL);
@@ -178,7 +178,6 @@ LCH_List *LCH_CallbackGetTable(void *const _conn, const char *const table_name,
    * TODO: Extract only the fields listed in the columns parameter, and in the
    * same order as they appear (see ticket CFE-4339).
    */
-  LCH_UNUSED(columns);
 
   return table;
 }
@@ -230,15 +229,13 @@ bool LCH_CallbackRollbackTransaction(void *const _conn) {
   return true;
 }
 
-bool LCH_CallbackInsertRecord(void *const _conn, const char *const table_name,
-                              const LCH_List *const columns,
+bool LCH_CallbackInsertRecord(void *const _conn,
+                              LCH_UNUSED const char *const table_name,
+                              LCH_UNUSED const LCH_List *const columns,
                               const LCH_List *const values) {
   CSVconn *const conn = (CSVconn *)_conn;
   assert(conn != NULL);
   assert(conn->table != NULL);
-
-  LCH_UNUSED(table_name);  // Intended for database systems.
-  LCH_UNUSED(columns);     // Intended for database systems.
 
   LCH_List *const record = LCH_ListCopy(
       values, (LCH_DuplicateFn)LCH_BufferDuplicate, LCH_BufferDestroy);
@@ -262,15 +259,13 @@ bool LCH_CallbackInsertRecord(void *const _conn, const char *const table_name,
   return true;
 }
 
-bool LCH_CallbackDeleteRecord(void *const _conn, const char *const table_name,
-                              const LCH_List *const primary_columns,
+bool LCH_CallbackDeleteRecord(void *const _conn,
+                              LCH_UNUSED const char *const table_name,
+                              LCH_UNUSED const LCH_List *const primary_columns,
                               const LCH_List *const primary_values) {
   CSVconn *const conn = (CSVconn *)_conn;
   assert(conn != NULL);
   assert(conn->table != NULL);
-
-  LCH_UNUSED(table_name);       // Intended for database systems.
-  LCH_UNUSED(primary_columns);  // Intended for database systems.
 
   const size_t num_records = LCH_ListLength(conn->table);
   assert(num_records > 0);
@@ -311,18 +306,15 @@ bool LCH_CallbackDeleteRecord(void *const _conn, const char *const table_name,
   return false;
 }
 
-bool LCH_CallbackUpdateRecord(void *const _conn, const char *const table_name,
-                              const LCH_List *const primary_columns,
-                              const LCH_List *const primary_values,
-                              const LCH_List *const subsidiary_columns,
-                              const LCH_List *const subsidiary_values) {
+bool LCH_CallbackUpdateRecord(
+    void *const _conn, LCH_UNUSED const char *const table_name,
+    LCH_UNUSED const LCH_List *const primary_columns,
+    const LCH_List *const primary_values,
+    LCH_UNUSED const LCH_List *const subsidiary_columns,
+    const LCH_List *const subsidiary_values) {
   CSVconn *const conn = (CSVconn *)_conn;
   assert(conn != NULL);
   assert(conn->table != NULL);
-
-  LCH_UNUSED(table_name);          // Intended for database systems.
-  LCH_UNUSED(primary_columns);     // Intended for database systems.
-  LCH_UNUSED(subsidiary_columns);  // Intended for database systems.
 
   const size_t num_records = LCH_ListLength(conn->table);
   assert(num_records > 0);

--- a/lib/patch.c
+++ b/lib/patch.c
@@ -5,6 +5,7 @@
 
 #include "files.h"
 #include "head.h"
+#include "definitions.h"
 
 LCH_Json *LCH_PatchCreate(const char *const lastknown) {
   LCH_Json *const patch = LCH_JsonObjectCreate();
@@ -13,53 +14,53 @@ LCH_Json *LCH_PatchCreate(const char *const lastknown) {
   }
 
   {
-    LCH_Buffer *const val = LCH_BufferFromString(PACKAGE_VERSION);
-    if (val == NULL) {
+    LCH_Json *const value = LCH_JsonNumberCreate((double)LCH_PATCH_VERSION);
+    if (value == NULL) {
       LCH_JsonDestroy(patch);
       return NULL;
     }
 
     const LCH_Buffer *const key = LCH_BufferStaticFromString("version");
-    if (!LCH_JsonObjectSetString(patch, key, val)) {
-      LCH_BufferDestroy(val);
+    if (!LCH_JsonObjectSet(patch, key, value)) {
+      LCH_JsonDestroy(value);
       LCH_JsonDestroy(patch);
       return NULL;
     }
   }
 
   {
-    LCH_Buffer *const val = LCH_BufferFromString(lastknown);
-    if (val == NULL) {
+    LCH_Buffer *const value = LCH_BufferFromString(lastknown);
+    if (value == NULL) {
       LCH_JsonDestroy(patch);
       return NULL;
     }
 
     const LCH_Buffer *const key = LCH_BufferStaticFromString("lastknown");
-    if (!LCH_JsonObjectSetString(patch, key, val)) {
+    if (!LCH_JsonObjectSetString(patch, key, value)) {
       LCH_JsonDestroy(patch);
       return NULL;
     }
   }
 
   {
-    const double val = (double)time(NULL);
+    const double value = (double)time(NULL);
     const LCH_Buffer *const key = LCH_BufferStaticFromString("timestamp");
-    if (!LCH_JsonObjectSetNumber(patch, key, val)) {
+    if (!LCH_JsonObjectSetNumber(patch, key, value)) {
       LCH_JsonDestroy(patch);
       return NULL;
     }
   }
 
   {
-    LCH_Json *const val = LCH_JsonArrayCreate();
-    if (val == NULL) {
+    LCH_Json *const value = LCH_JsonArrayCreate();
+    if (value == NULL) {
       LCH_JsonDestroy(patch);
       return NULL;
     }
 
     const LCH_Buffer *const key = LCH_BufferStaticFromString("blocks");
-    if (!LCH_JsonObjectSet(patch, key, val)) {
-      LCH_JsonDestroy(val);
+    if (!LCH_JsonObjectSet(patch, key, value)) {
+      LCH_JsonDestroy(value);
       LCH_JsonDestroy(patch);
       return NULL;
     }

--- a/lib/patch.c
+++ b/lib/patch.c
@@ -3,9 +3,9 @@
 #include <assert.h>
 #include <time.h>
 
+#include "definitions.h"
 #include "files.h"
 #include "head.h"
-#include "definitions.h"
 
 LCH_Json *LCH_PatchCreate(const char *const lastknown) {
   LCH_Json *const patch = LCH_JsonObjectCreate();

--- a/lib/patch.h
+++ b/lib/patch.h
@@ -5,6 +5,10 @@
 
 #include "json.h"
 
+bool LCH_PatchGetVersion(const LCH_Json *patch, size_t *version);
+
+LCH_Json *LCH_PatchParse(const char *raw_buffer, size_t raw_length);
+
 LCH_Json *LCH_PatchCreate(const char *lastseen);
 
 bool LCH_PatchAppendBlock(const LCH_Json *patch, LCH_Json *block);

--- a/lib/string_lib.c
+++ b/lib/string_lib.c
@@ -245,8 +245,8 @@ char *LCH_StringFormat(const char *const format, ...) {
   }
 
   va_start(ap, format);
-  const int ret = vsnprintf(str, (size_t)length + 1, format, ap);
-  LCH_UNUSED(ret);
+  LCH_NDEBUG_UNUSED const int ret =
+      vsnprintf(str, (size_t)length + 1, format, ap);
   va_end(ap);
   assert(ret == length);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -17,7 +17,8 @@ unit_test_SOURCES = unit_test.c \
     check_list.c \
     check_table.c \
     check_utils.c \
-    check_instance.c
+    check_instance.c \
+    check_patch.c
 unit_test_CFLAGS = @CHECK_CFLAGS@
 unit_test_LDADD = @CHECK_LIBS@ $(top_builddir)/lib/libleech.la
 endif

--- a/tests/check_block.c
+++ b/tests/check_block.c
@@ -25,20 +25,18 @@ START_TEST(test_LCH_BlockCreate) {
   const char *const head = "I'm the parent";
   LCH_Json *const block = LCH_BlockCreate(head, payload);
 
-  ck_assert(
-      LCH_JsonObjectHasKey(block, LCH_BufferStaticFromString("timestamp")));
-  LCH_LOG_INFO("timestamp: %f",
-               LCH_JsonNumberGet(LCH_JsonObjectGet(
-                   block, LCH_BufferStaticFromString("timestamp"))));
-
-  ck_assert(LCH_JsonObjectHasKey(block, LCH_BufferStaticFromString("parent")));
-  ck_assert_str_eq(LCH_BufferData(LCH_JsonObjectGetString(
-                       block, LCH_BufferStaticFromString("parent"))),
-                   head);
-  LCH_LOG_INFO("parent: %s", LCH_JsonStringGet(LCH_JsonObjectGet(
-                                 block, LCH_BufferStaticFromString("parent"))));
-
-  ck_assert(LCH_JsonObjectHasKey(block, LCH_BufferStaticFromString("payload")));
+  {
+    const LCH_Buffer *const key = LCH_BufferStaticFromString("timestamp");
+    ck_assert(LCH_JsonObjectHasKey(block, key));
+  }
+  {
+    const LCH_Buffer *const key = LCH_BufferStaticFromString("parent");
+    ck_assert(LCH_JsonObjectHasKey(block, key));
+  }
+  {
+    const LCH_Buffer *const key = LCH_BufferStaticFromString("payload");
+    ck_assert(LCH_JsonObjectHasKey(block, key));
+  }
 
   LCH_JsonDestroy(block);
 }

--- a/tests/check_json.c
+++ b/tests/check_json.c
@@ -798,23 +798,44 @@ START_TEST(test_LCH_JsonComposeFalse) {
 END_TEST
 
 START_TEST(test_LCH_JsonComposeNumber) {
-  LCH_Json *const json = LCH_JsonNumberCreate(123.0);
-  ck_assert_ptr_nonnull(json);
   {
-    LCH_Buffer *const actual = LCH_JsonCompose(json, false);
-    ck_assert_ptr_nonnull(actual);
+    LCH_Json *const json = LCH_JsonNumberCreate(123.0);
+    ck_assert_ptr_nonnull(json);
+    {
+      LCH_Buffer *const actual = LCH_JsonCompose(json, false);
+      ck_assert_ptr_nonnull(actual);
 
-    ck_assert_str_eq(LCH_BufferData(actual), "123.000000");
-    LCH_BufferDestroy(actual);
+      ck_assert_str_eq(LCH_BufferData(actual), "123");
+      LCH_BufferDestroy(actual);
+    }
+    {
+      LCH_Buffer *const actual = LCH_JsonCompose(json, true);
+      ck_assert_ptr_nonnull(actual);
+
+      ck_assert_str_eq(LCH_BufferData(actual), "123\n");
+      LCH_BufferDestroy(actual);
+    }
+    LCH_JsonDestroy(json);
   }
   {
-    LCH_Buffer *const actual = LCH_JsonCompose(json, true);
-    ck_assert_ptr_nonnull(actual);
+    LCH_Json *const json = LCH_JsonNumberCreate(123.456);
+    ck_assert_ptr_nonnull(json);
+    {
+      LCH_Buffer *const actual = LCH_JsonCompose(json, false);
+      ck_assert_ptr_nonnull(actual);
 
-    ck_assert_str_eq(LCH_BufferData(actual), "123.000000\n");
-    LCH_BufferDestroy(actual);
+      ck_assert_str_eq(LCH_BufferData(actual), "123.456");
+      LCH_BufferDestroy(actual);
+    }
+    {
+      LCH_Buffer *const actual = LCH_JsonCompose(json, true);
+      ck_assert_ptr_nonnull(actual);
+
+      ck_assert_str_eq(LCH_BufferData(actual), "123.456\n");
+      LCH_BufferDestroy(actual);
+    }
+    LCH_JsonDestroy(json);
   }
-  LCH_JsonDestroy(json);
 }
 END_TEST
 
@@ -981,7 +1002,7 @@ START_TEST(test_LCH_JsonCompose) {
       "{\n"
       "  \"version\": \"" PACKAGE_VERSION
       "\",\n"
-      "  \"max_chain_length\": 64.000000,\n"
+      "  \"max_chain_length\": 64,\n"
       "  \"compression\": false,\n"
       "  \"tables\": {\n"
       "    \"BTL\": {\n"

--- a/tests/check_patch.c
+++ b/tests/check_patch.c
@@ -1,0 +1,63 @@
+#include <check.h>
+
+#include "../lib/definitions.h"
+#include "../lib/json.h"
+#include "../lib/patch.h"
+
+START_TEST(test_LCH_PatchGetVersion) {
+  const char *const raw = "{ \"version\": 1 }";
+  LCH_Json *const patch = LCH_JsonParse(raw, strlen(raw));
+  ck_assert_ptr_nonnull(patch);
+
+  size_t version;
+  ck_assert(LCH_PatchGetVersion(patch, &version));
+  ck_assert_uint_eq(version, 1);
+
+  LCH_JsonDestroy(patch);
+}
+END_TEST
+
+START_TEST(test_LCH_PatchParse) {
+  {
+    LCH_Buffer *const buffer = LCH_BufferCreate();
+    ck_assert_ptr_nonnull(buffer);
+    ck_assert(LCH_BufferPrintFormat(buffer, "{ \"version\": %zu }",
+                                    LCH_PATCH_VERSION));
+
+    const size_t raw_length = LCH_BufferLength(buffer);
+    const char *const raw_buffer = LCH_BufferToString(buffer);
+
+    LCH_Json *const patch = LCH_PatchParse(raw_buffer, raw_length);
+    ck_assert_ptr_nonnull(patch);
+
+    LCH_JsonDestroy(patch);
+  }
+  {
+    LCH_Buffer *const buffer = LCH_BufferCreate();
+    ck_assert_ptr_nonnull(buffer);
+    ck_assert(LCH_BufferPrintFormat(buffer, "{ \"version\": %zu }",
+                                    LCH_PATCH_VERSION + 1));
+
+    const size_t raw_length = LCH_BufferLength(buffer);
+    const char *const raw_buffer = LCH_BufferToString(buffer);
+
+    LCH_Json *const patch = LCH_PatchParse(raw_buffer, raw_length);
+    ck_assert_ptr_null(patch);
+  }
+}
+END_TEST
+
+Suite *PatchSuite(void) {
+  Suite *s = suite_create("list.c");
+  {
+    TCase *tc = tcase_create("LCH_PatchGetVersion");
+    tcase_add_test(tc, test_LCH_PatchGetVersion);
+    suite_add_tcase(s, tc);
+  }
+  {
+    TCase *tc = tcase_create("LCH_PatchParse");
+    tcase_add_test(tc, test_LCH_PatchParse);
+    suite_add_tcase(s, tc);
+  }
+  return s;
+}

--- a/tests/check_patch.c
+++ b/tests/check_patch.c
@@ -25,12 +25,13 @@ START_TEST(test_LCH_PatchParse) {
                                     LCH_PATCH_VERSION));
 
     const size_t raw_length = LCH_BufferLength(buffer);
-    const char *const raw_buffer = LCH_BufferToString(buffer);
+    char *const raw_buffer = LCH_BufferToString(buffer);
 
     LCH_Json *const patch = LCH_PatchParse(raw_buffer, raw_length);
     ck_assert_ptr_nonnull(patch);
 
     LCH_JsonDestroy(patch);
+    free(raw_buffer);
   }
   {
     LCH_Buffer *const buffer = LCH_BufferCreate();
@@ -39,10 +40,11 @@ START_TEST(test_LCH_PatchParse) {
                                     LCH_PATCH_VERSION + 1));
 
     const size_t raw_length = LCH_BufferLength(buffer);
-    const char *const raw_buffer = LCH_BufferToString(buffer);
+    char *const raw_buffer = LCH_BufferToString(buffer);
 
     LCH_Json *const patch = LCH_PatchParse(raw_buffer, raw_length);
     ck_assert_ptr_null(patch);
+    free(raw_buffer);
   }
 }
 END_TEST

--- a/tests/unit_test.c
+++ b/tests/unit_test.c
@@ -17,6 +17,7 @@ Suite *UtilsSuite(void);
 Suite *InstanceSuite(void);
 Suite *FilesSuite(void);
 Suite *StringLibSuite(void);
+Suite *PatchSuite(void);
 
 int main(int argc, char *argv[]) {
   SRunner *sr = srunner_create(BufferSuite());
@@ -29,6 +30,7 @@ int main(int argc, char *argv[]) {
   srunner_add_suite(sr, BlockSuite());
   srunner_add_suite(sr, TableSuite());
   srunner_add_suite(sr, InstanceSuite());
+  srunner_add_suite(sr, PatchSuite());
 
   if (argc > 1 && strcmp(argv[1], "no-fork") == 0) {
     srunner_set_fork_status(sr, CK_NOFORK);


### PR DESCRIPTION
- **JSON composer now omits trailing zeroes in numbers**
- **Patch version number is now an incrementing integer**
- **Block version number is now an incrementing integer**
- **JSON composer/parser no longer iterprets escape sequences**
- **Version number is now checked when parsing patches**
- **Added unit test for LCH_PatchGetVersion & LCH_PatchParse**
- **Added macro LCH_NDEBUG_UNUSED**
- **Version number is now checked when parsing blocks**
