### PR TITLE
Fixed undefined header file error on Windows

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 # Process this file with autoconf to produce a configure script.
 
 AC_PREREQ([2.63])
-AC_INIT([leech], [0.1.9], [https://github.com/larsewi/leech/issues], [leech],
+AC_INIT([leech], [0.1.10], [https://github.com/larsewi/leech/issues], [leech],
         [https://github.com/larsewi/leech])
 AC_CONFIG_SRCDIR([lib/leech.h])
 

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -1,13 +1,19 @@
 #include "buffer.h"
 
-#include <arpa/inet.h>
 #include <assert.h>
 #include <ctype.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdarg.h>
+#include <stdint.h>
 #include <string.h>
 #include <unistd.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else  // _WIN32
+#include <arpa/inet.h>
+#endif  // _WIN32
 
 #include "definitions.h"
 #include "files.h"

--- a/tests/check_buffer.c
+++ b/tests/check_buffer.c
@@ -1,5 +1,10 @@
-#include <arpa/inet.h>
 #include <check.h>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#else  // _WIN32
+#include <arpa/inet.h>
+#endif  // _WIN32
 
 #include "../lib/buffer.h"
 


### PR DESCRIPTION
fatal error: arpa/inet.h: No such file or directory

Ticket: None
Changelog: None
Signed-off-by: Lars Erik Wik <lars.erik.wik@northern.tech>
