### PR TITLE
Now prints hex representation of non-printable keys when logging them

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -7,8 +7,8 @@ AC_INIT([leech], [0.1.21], [https://github.com/larsewi/leech/issues], [leech],
         [https://github.com/larsewi/leech])
 AC_CONFIG_SRCDIR([lib/leech.h])
 
-AC_DEFINE([LCH_DEFAULT_PREFERED_CHAIN_LENGTH], 2048,
-          [Default prefered chain length used when puring blocks])
+AC_DEFINE([LCH_DEFAULT_PREFERRED_CHAIN_LENGTH], 2048,
+          [Default preferred chain length used when pruning blocks])
 AC_DEFINE([LCH_JSON_PRETTY_INDENT_SIZE], 2,
           [Indent size used when composing pretty JSON])
 AC_DEFINE([LCH_BUFFER_SIZE], 1024,

--- a/lib/block.c
+++ b/lib/block.c
@@ -140,10 +140,10 @@ LCH_Json *LCH_BlockLoad(const char *const work_dir,
 
   LCH_Json *const block = LCH_JsonParseFile(path);
   if (block == NULL) {
-    LCH_LOG_ERROR("Failed to parse block with identifer %.7s", block_id);
+    LCH_LOG_ERROR("Failed to parse block with identifier %.7s", block_id);
     return NULL;
   }
-  LCH_LOG_DEBUG("Parsed block with identifer %.7s", block_id);
+  LCH_LOG_DEBUG("Parsed block with identifier %.7s", block_id);
 
   size_t version;
   if (!LCH_BlockGetVersion(block, &version)) {

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -94,7 +94,8 @@ bool LCH_BufferPrintFormat(LCH_Buffer *const self, const char *const format,
   va_end(ap);
   if (length < 0) {
     LCH_LOG_ERROR(
-        "Failed to calculate length needed to print formatted string to buffer: "
+        "Failed to calculate length needed to print formatted string to "
+        "buffer: "
         "%s",
         strerror(errno));
     self->buffer[self->length] = '\0';
@@ -369,4 +370,16 @@ LCH_Buffer *LCH_BufferDuplicate(const LCH_Buffer *const original) {
          original->length + 1 /* NULL-byte */);
   duplicate->length = original->length;
   return duplicate;
+}
+
+bool LCH_BufferIsPrintable(const LCH_Buffer *const self) {
+  assert(self != NULL);
+  assert(self->buffer != NULL);
+
+  for (size_t i = 0; i < self->length; i++) {
+    if ((self->buffer[i] < 32) || (self->buffer[i] >= 127)) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/lib/buffer.c
+++ b/lib/buffer.c
@@ -94,7 +94,7 @@ bool LCH_BufferPrintFormat(LCH_Buffer *const self, const char *const format,
   va_end(ap);
   if (length < 0) {
     LCH_LOG_ERROR(
-        "Failed to calulate length needed to print formatted string to buffer: "
+        "Failed to calculate length needed to print formatted string to buffer: "
         "%s",
         strerror(errno));
     self->buffer[self->length] = '\0';

--- a/lib/buffer.h
+++ b/lib/buffer.h
@@ -46,8 +46,8 @@ void LCH_BufferSet(LCH_Buffer *buffer, size_t offset, const void *value,
 
 /**
  * @brief Converts bytes into its hexadecimal string representation
- * @param bytes Byte buffer
  * @param hex Hexadecimal buffer
+ * @param bytes Byte buffer
  * @return True on success, false on error
  */
 bool LCH_BufferBytesToHex(LCH_Buffer *hex, const LCH_Buffer *bytes);

--- a/lib/buffer.h
+++ b/lib/buffer.h
@@ -56,4 +56,13 @@ void LCH_BufferTrim(LCH_Buffer *buffer, char ch);
 
 bool LCH_BufferAppendBuffer(LCH_Buffer *buffer, const LCH_Buffer *append);
 
+/**
+ * @brief Checks if buffer contains only printable characters. I.e., character
+ *        code 32 - 127 (not included).
+ * @param buffer Buffer to check
+ * @return True if all characters are printable, false if one or more
+ *         characters are non-printable.
+ */
+bool LCH_BufferIsPrintable(const LCH_Buffer *buffer);
+
 #endif  // _LEECH_BUFFER_H

--- a/lib/instance.c
+++ b/lib/instance.c
@@ -220,7 +220,7 @@ const char *LCH_InstanceGetWorkDirectory(const LCH_Instance *const self) {
   return self->work_dir;
 }
 
-size_t LCH_InstanceGetPrefferedChainLength(const LCH_Instance *const instance) {
+size_t LCH_InstanceGetPreferredChainLength(const LCH_Instance *const instance) {
   assert(instance != NULL);
   return instance->chain_length;
 }

--- a/lib/instance.c
+++ b/lib/instance.c
@@ -87,7 +87,7 @@ LCH_Instance *LCH_InstanceLoad(const char *const work_dir) {
         return NULL;
       }
     } else {
-      instance->chain_length = LCH_DEFAULT_PREFERED_CHAIN_LENGTH;
+      instance->chain_length = LCH_DEFAULT_PREFERRED_CHAIN_LENGTH;
     }
     LCH_LOG_DEBUG("config[\"chain_length\"] = %zu", instance->chain_length);
   }

--- a/lib/instance.h
+++ b/lib/instance.h
@@ -42,7 +42,7 @@ const LCH_List *LCH_InstanceGetTables(const LCH_Instance *instance);
  */
 const char *LCH_InstanceGetWorkDirectory(const LCH_Instance *instance);
 
-size_t LCH_InstanceGetPrefferedChainLength(const LCH_Instance *instance);
+size_t LCH_InstanceGetPreferredChainLength(const LCH_Instance *instance);
 
 bool LCH_InstanceShouldPrettyPrint(const LCH_Instance *instance);
 

--- a/lib/json.c
+++ b/lib/json.c
@@ -446,7 +446,7 @@ const LCH_Buffer *LCH_JsonArrayGetString(const LCH_Json *const json,
     const char *const type = LCH_JsonGetTypeAsString(child);
     LCH_LOG_ERROR(
         "Failed to get value from JSON array at index %zu: "
-        "Expected type string, type %s",
+        "Expected type string, but found type %s",
         index, type);
     return NULL;
   }

--- a/lib/leech.c
+++ b/lib/leech.c
@@ -25,7 +25,7 @@ const char *LCH_Version(void) { return PACKAGE_VERSION; }
 
 static bool Purge(const LCH_Instance *const instance) {
   const char *const work_dir = LCH_InstanceGetWorkDirectory(instance);
-  const size_t chain_length = LCH_InstanceGetPrefferedChainLength(instance);
+  const size_t chain_length = LCH_InstanceGetPreferredChainLength(instance);
 
   char *const head = LCH_HeadGet("HEAD", work_dir);
   if (head == NULL) {

--- a/lib/table.c
+++ b/lib/table.c
@@ -104,7 +104,7 @@ LCH_TableInfo *LCH_TableInfoLoad(const char *const identifer,
 
   LCH_TableInfo *const info = (LCH_TableInfo *)malloc(sizeof(LCH_TableInfo));
   if (info == NULL) {
-    LCH_LOG_ERROR("malloc(3): Failed to allocate memeory: %s", strerror(errno));
+    LCH_LOG_ERROR("malloc(3): Failed to allocate memory: %s", strerror(errno));
     return NULL;
   }
 

--- a/lib/utils.c
+++ b/lib/utils.c
@@ -7,9 +7,11 @@
 
 #include "buffer.h"
 #include "csv.h"
+#include "leech.h"
 #include "list.h"
 #include "logger.h"
 #include "sha1.h"
+#include "string_lib.h"
 
 /******************************************************************************/
 
@@ -227,4 +229,30 @@ bool LCH_DoubleToSize(const double number, size_t *const size) {
   }
   *size = (size_t)number;
   return true;
+}
+
+/******************************************************************************/
+
+char *LCH_BufferToPrintable(const LCH_Buffer *const buffer) {
+  assert(buffer != NULL);
+
+  char *str;
+  if (LCH_BufferIsPrintable(buffer)) {
+    str = LCH_StringFormat("\"%s\"", LCH_BufferData(buffer));
+  } else {
+    LCH_Buffer *hex = LCH_BufferCreate();
+    if (hex == NULL) {
+      return NULL;
+    }
+
+    if (!LCH_BufferBytesToHex(hex, buffer)) {
+      return NULL;
+    }
+
+    str = LCH_StringFormat("b\"%s\"", LCH_BufferData(hex));
+
+    LCH_BufferDestroy(hex);
+  }
+
+  return str;
 }

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -18,7 +18,7 @@ bool LCH_MessageDigest(const unsigned char *message, size_t length,
 bool LCH_ListAppendBufferDuplicate(LCH_List *list, const LCH_Buffer *buffer);
 
 /**
- * @brief Safily cast double to size_t.
+ * @brief Safely cast double to size_t.
  * @param number value to cast from
  * @param size value to cast to
  * @return True on success, false if value is out of bounds.

--- a/lib/utils.h
+++ b/lib/utils.h
@@ -26,4 +26,17 @@ bool LCH_ListAppendBufferDuplicate(LCH_List *list, const LCH_Buffer *buffer);
  */
 bool LCH_DoubleToSize(double number, size_t *size);
 
+/**
+ * @brief Returns a printable string from buffer.
+ * @param buffer The buffer to generate printable string from
+ * @note The returned string must be free'd with free(3)
+ * @return If the buffer content is printable the returned string contains the
+ *         original content within two double quotes (i.e., ""). However, if
+ *         the buffer content is not printable the returned string contains the
+ *         hexadecimal representation of the string within two double quotes
+ *         preceeded by the letter b (i.e., b""). NULL is returned in case of
+ *         memory errors.
+ */
+char *LCH_BufferToPrintable(const LCH_Buffer *buffer);
+
 #endif  // _LEECH_UTILS_H

--- a/tests/acceptance.py
+++ b/tests/acceptance.py
@@ -7,6 +7,9 @@ from datetime import datetime
 import os
 import json
 
+# If you want to run this as current user
+# sudo -u postgres createuser -s larsewi
+
 SEED = 1  # Seed used by random generator
 CHANCE = 20  # Percent chance of report collection
 HUB_ID = "SHA=b9353fd"

--- a/tests/check_buffer.c
+++ b/tests/check_buffer.c
@@ -190,6 +190,46 @@ START_TEST(test_LCH_BufferBytesToHex) {
 }
 END_TEST
 
+START_TEST(test_LCH_BufferIsPrintable) {
+  {
+    LCH_Buffer *buffer = LCH_BufferFromString("leech");
+    LCH_BufferAppend(buffer, 0);
+    ck_assert(!LCH_BufferIsPrintable(buffer));
+    LCH_BufferDestroy(buffer);
+  }
+  {
+    LCH_Buffer *buffer = LCH_BufferFromString("leech");
+    LCH_BufferAppend(buffer, 31);
+    ck_assert(!LCH_BufferIsPrintable(buffer));
+    LCH_BufferDestroy(buffer);
+  }
+  {
+    LCH_Buffer *buffer = LCH_BufferFromString("leech");
+    LCH_BufferAppend(buffer, 32);
+    ck_assert(LCH_BufferIsPrintable(buffer));
+    LCH_BufferDestroy(buffer);
+  }
+  {
+    LCH_Buffer *buffer = LCH_BufferFromString("leech");
+    LCH_BufferAppend(buffer, 126);
+    ck_assert(LCH_BufferIsPrintable(buffer));
+    LCH_BufferDestroy(buffer);
+  }
+  {
+    LCH_Buffer *buffer = LCH_BufferFromString("leech");
+    LCH_BufferAppend(buffer, 127);
+    ck_assert(!LCH_BufferIsPrintable(buffer));
+    LCH_BufferDestroy(buffer);
+  }
+  {
+    LCH_Buffer *buffer = LCH_BufferFromString("leech");
+    LCH_BufferAppend(buffer, 255);
+    ck_assert(!LCH_BufferIsPrintable(buffer));
+    LCH_BufferDestroy(buffer);
+  }
+}
+END_TEST
+
 Suite *BufferSuite(void) {
   Suite *s = suite_create("buffer.c");
   {
@@ -215,6 +255,11 @@ Suite *BufferSuite(void) {
   {
     TCase *tc = tcase_create("LCH_BufferBytesToHex");
     tcase_add_test(tc, test_LCH_BufferBytesToHex);
+    suite_add_tcase(s, tc);
+  }
+  {
+    TCase *tc = tcase_create("LCH_BufferIsPrintable");
+    tcase_add_test(tc, test_LCH_BufferIsPrintable);
     suite_add_tcase(s, tc);
   }
   return s;

--- a/tests/check_utils.c
+++ b/tests/check_utils.c
@@ -192,6 +192,49 @@ START_TEST(test_LCH_DoubleToSize) {
 }
 END_TEST
 
+START_TEST(test_LCH_BufferToPrintable) {
+  {
+    LCH_Buffer *buffer = LCH_BufferFromString("leech");
+    char *printable = LCH_BufferToPrintable(buffer);
+    ck_assert_str_eq(printable, "\"leech\"");
+    LCH_BufferDestroy(buffer);
+    free(printable);
+  }
+  {
+    LCH_Buffer *buffer = LCH_BufferFromString("leech");
+    LCH_BufferAppend(buffer, 31);
+    char *printable = LCH_BufferToPrintable(buffer);
+    ck_assert_str_eq(printable, "b\"6c656563681f\"");
+    LCH_BufferDestroy(buffer);
+    free(printable);
+  }
+  {
+    LCH_Buffer *buffer = LCH_BufferFromString("leech");
+    LCH_BufferAppend(buffer, 32);
+    char *printable = LCH_BufferToPrintable(buffer);
+    ck_assert_str_eq(printable, "\"leech \"");
+    LCH_BufferDestroy(buffer);
+    free(printable);
+  }
+  {
+    LCH_Buffer *buffer = LCH_BufferFromString("leech");
+    LCH_BufferAppend(buffer, 126);
+    char *printable = LCH_BufferToPrintable(buffer);
+    ck_assert_str_eq(printable, "\"leech~\"");
+    LCH_BufferDestroy(buffer);
+    free(printable);
+  }
+  {
+    LCH_Buffer *buffer = LCH_BufferFromString("leech");
+    LCH_BufferAppend(buffer, 127);
+    char *printable = LCH_BufferToPrintable(buffer);
+    ck_assert_str_eq(printable, "b\"6c656563687f\"");
+    LCH_BufferDestroy(buffer);
+    free(printable);
+  }
+}
+END_TEST
+
 Suite *UtilsSuite(void) {
   Suite *s = suite_create("utils.c");
   {
@@ -212,6 +255,11 @@ Suite *UtilsSuite(void) {
   {
     TCase *tc = tcase_create("LCH_DoubleToSize");
     tcase_add_test(tc, test_LCH_DoubleToSize);
+    suite_add_tcase(s, tc);
+  }
+  {
+    TCase *tc = tcase_create("LCH_BufferToPrintable");
+    tcase_add_test(tc, test_LCH_BufferToPrintable);
     suite_add_tcase(s, tc);
   }
   return s;


### PR DESCRIPTION
- **Fixed confusing log message in JSON API**
- **Added tip for how to run acceptance test**
- **Fixed log message typo in LCH_BlockLoad**
- **Fixed log msg typo in LCH_BufferPrintFormat**
- **Fixed typo in LCH_DEFAULT_PREFERRED_CHAIN_LENGTH macro**
- **Fixed typo in LCH_InstanceGetPreferredChainLength**
- **Fixed typo in log msg in LCH_TableInfoLoad**
- **Fixed typo doc string for LCH_DoubleToSize**
- **Added function LCH_BufferIsPrintable**
- **Added function LCH_BufferToPrintable**
- **Now converts keys to printable strings before logging them**
