### PR TITLE
CFE-4279: You can now disable merging of specific tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,9 @@ table `foo` could look something like this:
 }
 ```
 
+If you however want intermediate changes for an entire table, please check out
+the section on [disabling merging of blocks](#disable-merging-blocks).
+
 ## LCH_Purge()
 
 For each block created by a call to [`LCH_Commit()`](#lch_commit), a new file is
@@ -425,6 +428,7 @@ is an object containing multiple configuration parameters.
   "BTL": {
     "primary_fields": ["first_name", "last_name"],
     "subsidiary_fields": ["born"],
+    "merge_blocks": false, // Optional (default: true)
     "source": {
       "params": "beatles.csv",
       "schema": "leech",
@@ -453,6 +457,16 @@ composite primary key.
 The `"subsidiary_fields"` parameter should contain the column names of the
 remaining fields to be loaded by **leech**. This can be the empty list, in case
 all fields make up the primary composite key.
+
+### Disable merging blocks
+
+In some situations it's important to keep track of intermediate values. We
+already know that we can get an intermediate value from a specific record using
+[`LCH_History()`](#lch_history). However, you may want this for an entire table.
+In this case, you can set the `"merge_blocks"` parameter to `false` (it defaults
+to `true`) in the respective table definition. This completly disables [merging
+of blocks](#merging-blocks) for that table. Causing multiple blocks to be
+included in the patch. Other tables are however, merged into the last block.
 
 ### Source / Destination parameters
 

--- a/lib/block.c
+++ b/lib/block.c
@@ -194,6 +194,19 @@ LCH_Json *LCH_BlockRemovePayload(const LCH_Json *const block) {
   return payload_val;
 }
 
+bool LCH_BlockAppendPayload(const LCH_Json *const block,
+                            LCH_Json *const payload) {
+  assert(block != NULL);
+  assert(payload != NULL);
+
+  const LCH_Buffer key = LCH_BufferStaticFromString("payload");
+  if (!LCH_JsonObjectSet(block, &key, payload)) {
+    LCH_LOG_ERROR("Failed to append payload to block");
+    return false;
+  }
+  return true;
+}
+
 bool LCH_BlockGetTimestamp(const LCH_Json *const block,
                            double *const timestamp) {
   const LCH_Buffer key = LCH_BufferStaticFromString("timestamp");

--- a/lib/block.h
+++ b/lib/block.h
@@ -68,6 +68,14 @@ const LCH_Json *LCH_BlockGetPayload(const LCH_Json *block);
 LCH_Json *LCH_BlockRemovePayload(const LCH_Json *block);
 
 /**
+ * @brief Append payload to block
+ * @param block The block
+ * @param payload The payload
+ * @return False in case of failure
+ */
+bool LCH_BlockAppendPayload(const LCH_Json *block, LCH_Json *payload);
+
+/**
  * @brief Get the timestamp from whence the block was created
  * @param block The block
  * @param timestamp The variable in which to store the timestamp

--- a/lib/delta.c
+++ b/lib/delta.c
@@ -139,27 +139,36 @@ bool LCH_DeltaGetNumOperations(const LCH_Json *const delta,
                                size_t *const num_deletes,
                                size_t *const num_updates) {
   if (num_inserts != NULL) {
-    const LCH_Json *const inserts = LCH_DeltaGetInserts(delta);
-    if (inserts == NULL) {
-      return false;
+    LCH_Buffer key = LCH_BufferStaticFromString("inserts");
+    if (LCH_JsonObjectHasKey(delta, &key)) {
+      const LCH_Json *const inserts = LCH_DeltaGetInserts(delta);
+      assert(inserts != NULL);
+      *num_inserts = LCH_JsonObjectLength(inserts);
+    } else {
+      *num_inserts = 0;
     }
-    *num_inserts = LCH_JsonObjectLength(inserts);
   }
 
   if (num_deletes != NULL) {
-    const LCH_Json *const deletes = LCH_DeltaGetDeletes(delta);
-    if (deletes == NULL) {
-      return false;
+    LCH_Buffer key = LCH_BufferStaticFromString("deletes");
+    if (LCH_JsonObjectHasKey(delta, &key)) {
+      const LCH_Json *const deletes = LCH_DeltaGetDeletes(delta);
+      assert(deletes != NULL);
+      *num_deletes = LCH_JsonObjectLength(deletes);
+    } else {
+      *num_deletes = 0;
     }
-    *num_deletes = LCH_JsonObjectLength(deletes);
   }
 
   if (num_updates != NULL) {
-    const LCH_Json *const updates = LCH_DeltaGetUpdates(delta);
-    if (updates == NULL) {
-      return false;
+    LCH_Buffer key = LCH_BufferStaticFromString("updates");
+    if (LCH_JsonObjectHasKey(delta, &key)) {
+      const LCH_Json *const updates = LCH_DeltaGetUpdates(delta);
+      assert(updates != NULL);
+      *num_updates = LCH_JsonObjectLength(updates);
+    } else {
+      *num_deletes = 0;
     }
-    *num_updates = LCH_JsonObjectLength(updates);
   }
 
   return true;

--- a/lib/json.c
+++ b/lib/json.c
@@ -830,6 +830,14 @@ size_t LCH_JsonArrayLength(const LCH_Json *const json) {
   return length;
 }
 
+void LCH_JsonArrayReverse(const LCH_Json *const json) {
+  assert(json != NULL);
+  assert(LCH_JsonIsArray(json));
+  assert(json->array != NULL);
+
+  LCH_ListReverse(json->array);
+}
+
 /****************************************************************************/
 
 LCH_Json *LCH_JsonObjectKeysSetMinus(const LCH_Json *const left,

--- a/lib/json.h
+++ b/lib/json.h
@@ -554,6 +554,8 @@ size_t LCH_JsonObjectLength(const LCH_Json *json);
  */
 size_t LCH_JsonArrayLength(const LCH_Json *json);
 
+void LCH_JsonArrayReverse(const LCH_Json *json);
+
 /****************************************************************************/
 
 /**

--- a/lib/leech.c
+++ b/lib/leech.c
@@ -354,9 +354,12 @@ static LCH_Json *CreateEmptyBlock(const char *const parent_id) {
 }
 
 static LCH_Json *MergeBlocks(const LCH_Instance *const instance,
-                             const char *const final_id,
-                             LCH_Json *const child) {
+                             const char *const final_id, LCH_Json *const child,
+                             const LCH_Json *const patch) {
   assert(instance != NULL);
+  assert(final_id != NULL);
+  assert(child != NULL);
+  assert(patch != NULL);
 
   const char *const work_dir = LCH_InstanceGetWorkDirectory(instance);
   const char *const parent_id = LCH_BlockGetParentId(child);
@@ -381,36 +384,29 @@ static LCH_Json *MergeBlocks(const LCH_Instance *const instance,
     return NULL;
   }
 
-  LCH_Json *const child_payload = LCH_BlockRemovePayload(child);
-  LCH_JsonDestroy(child);  // We don't need the child block anymore
+  const LCH_Json *child_payload = LCH_BlockGetPayload(child);
   if (child_payload == NULL) {
+    LCH_JsonDestroy(child);
     LCH_JsonDestroy(parent);
     return NULL;
   }
 
-  LCH_Buffer *const key = LCH_BufferFromString("id");
-  if (key == NULL) {
-    LCH_JsonDestroy(child_payload);
-    LCH_JsonDestroy(parent);
-    return NULL;
-  }
-
+  size_t num_keep = 0; /* Number of child deltas to keep after merge */
+  LCH_Buffer id_key = LCH_BufferStaticFromString("id");
   const size_t num_parent_deltas = LCH_JsonArrayLength(parent_payload);
-  while (LCH_JsonArrayLength(child_payload) > 0) {
+  while (LCH_JsonArrayLength(child_payload) > num_keep) {
     LCH_Json *const child_delta = LCH_JsonArrayRemoveObject(child_payload, 0);
     if (child_delta == NULL) {
-      LCH_BufferDestroy(key);
-      LCH_JsonDestroy(child_payload);
+      LCH_JsonDestroy(child);
       LCH_JsonDestroy(parent);
       return NULL;
     }
 
     const LCH_Buffer *const child_table_id =
-        LCH_JsonObjectGetString(child_delta, key);
+        LCH_JsonObjectGetString(child_delta, &id_key);
     if (child_table_id == NULL) {
       LCH_JsonDestroy(child_delta);
-      LCH_BufferDestroy(key);
-      LCH_JsonDestroy(child_payload);
+      LCH_JsonDestroy(child);
       LCH_JsonDestroy(parent);
       return NULL;
     }
@@ -422,18 +418,16 @@ static LCH_Json *MergeBlocks(const LCH_Instance *const instance,
       parent_delta = LCH_JsonArrayGetObject(parent_payload, i);
       if (parent_delta == NULL) {
         LCH_JsonDestroy(child_delta);
-        LCH_BufferDestroy(key);
-        LCH_JsonDestroy(child_payload);
+        LCH_JsonDestroy(child);
         LCH_JsonDestroy(parent);
         return NULL;
       }
 
       const LCH_Buffer *const parent_table_id =
-          LCH_JsonObjectGetString(parent_delta, key);
+          LCH_JsonObjectGetString(parent_delta, &id_key);
       if (parent_table_id == NULL) {
         LCH_JsonDestroy(child_delta);
-        LCH_BufferDestroy(key);
-        LCH_JsonDestroy(child_payload);
+        LCH_JsonDestroy(child);
         LCH_JsonDestroy(parent);
         return NULL;
       }
@@ -451,30 +445,75 @@ static LCH_Json *MergeBlocks(const LCH_Instance *const instance,
             "table '%s'",
             child_table_id);
         LCH_JsonDestroy(child_delta);
-        LCH_BufferDestroy(key);
-        LCH_JsonDestroy(child_payload);
+        LCH_JsonDestroy(child);
         LCH_JsonDestroy(parent);
         return NULL;
       }
+
+      // Check if child delta is empty
+      size_t num_inserts = 0, num_deletes = 0, num_updates = 0;
+      if (!LCH_DeltaGetNumOperations(child_delta, &num_inserts, &num_deletes,
+                                     &num_updates)) {
+        LCH_LOG_ERROR(
+            "Failed to get numer of remaining delta operations in table '%s' "
+            "after merging blocks",
+            child_table_id);
+        LCH_JsonDestroy(child_delta);
+        LCH_JsonDestroy(child);
+        LCH_JsonDestroy(parent);
+        return NULL;
+      }
+
+      if (num_inserts + num_deletes + num_updates > 0) {
+        /* There is still stuff left in child delta. Most likely due the merging
+         * of blocks being disabled for some tables. Let's put it back to the
+         * child payload. */
+        if (!LCH_JsonArrayAppend(child_payload, child_delta)) {
+          LCH_LOG_ERROR(
+              "Failed to add delta for table '%s' back to child block",
+              child_table_id);
+          LCH_JsonDestroy(child_delta);
+          LCH_JsonDestroy(child);
+          LCH_JsonDestroy(parent);
+          return NULL;
+        }
+        num_keep += 1;
+      } else {
+        /* Nothing left in child delta, we can delete it */
+        LCH_JsonDestroy(child_delta);
+      }
     } else {
+      /* Even though some tables can have disabled merging of blocks, it's still
+       * fine to move deltas from one block to the next as long as it does not
+       * hide any intermediary states. This is one of those cases. */
       if (!LCH_JsonArrayAppend(parent, child_delta)) {
         LCH_LOG_ERROR(
             "Failed to append child block delta for table '%s' to parent block "
             "payload",
             child_table_id);
         LCH_JsonDestroy(child_delta);
-        LCH_BufferDestroy(key);
-        LCH_JsonDestroy(child_payload);
+        LCH_JsonDestroy(child);
         LCH_JsonDestroy(parent);
         return NULL;
       }
     }
-    LCH_JsonDestroy(child_delta);
   }
 
-  LCH_BufferDestroy(key);
-  LCH_JsonDestroy(child_payload);
-  LCH_Json *const merged = MergeBlocks(instance, final_id, parent);
+  if (LCH_JsonArrayLength(child_payload) > 0) {
+    /* Child payload did not get fully merged. Most likely due to merging being
+     * disabled for some tables. We'll add the block back to the patch payload.
+     */
+    if (!LCH_PatchAppendBlock(patch, child)) {
+      LCH_LOG_ERROR("Failed to child block to patch");
+      LCH_JsonDestroy(child);
+      LCH_JsonDestroy(parent);
+      return NULL;
+    }
+  } else {
+    LCH_JsonDestroy(child);
+  }
+
+  LCH_Json *const merged = MergeBlocks(instance, final_id, parent, patch);
   return merged;
 }
 
@@ -525,7 +564,7 @@ LCH_Buffer *LCH_Diff(const char *const work_dir, const char *const argument) {
     return NULL;
   }
 
-  LCH_Json *const block = MergeBlocks(instance, final_id, empty);
+  LCH_Json *const block = MergeBlocks(instance, final_id, empty, patch);
   if (block == NULL) {
     LCH_LOG_ERROR("Failed to generate patch file");
     LCH_JsonDestroy(patch);

--- a/lib/list.c
+++ b/lib/list.c
@@ -266,3 +266,13 @@ bool LCH_ListInsert(LCH_List *const list, const size_t index, void *const value,
   list->length += 1;
   return true;
 }
+
+void LCH_ListReverse(LCH_List *const list) {
+  assert(list != NULL);
+
+  for (size_t i = 0; i < (list->length / 2); i++) {
+    void *tmp = list->buffer[i];
+    list->buffer[i] = list->buffer[list->length - 1 - i];
+    list->buffer[list->length - 1 - i] = tmp;
+  }
+}

--- a/lib/list.h
+++ b/lib/list.h
@@ -10,4 +10,10 @@
  * Put private LCH_List functions here:
  */
 
+/**
+ * @brief Reverese the order of elements in the list
+ * @param list The list
+ */
+void LCH_ListReverse(LCH_List *list);
+
 #endif  // _LEECH_LIST_H

--- a/lib/patch.c
+++ b/lib/patch.c
@@ -122,6 +122,17 @@ bool LCH_PatchAppendBlock(const LCH_Json *const patch, LCH_Json *const block) {
   return true;
 }
 
+bool LCH_PatchReverseBlocks(const LCH_Json *patch) {
+  const LCH_Buffer key = LCH_BufferStaticFromString("blocks");
+  const LCH_Json *const blocks = LCH_JsonObjectGetArray(patch, &key);
+  if (blocks == NULL) {
+    return false;
+  }
+
+  LCH_JsonArrayReverse(blocks);
+  return true;
+}
+
 bool LCH_PatchUpdateLastKnown(const LCH_Json *const patch,
                               const char *const work_dir,
                               const char *const identifier) {

--- a/lib/patch.h
+++ b/lib/patch.h
@@ -13,6 +13,8 @@ LCH_Json *LCH_PatchCreate(const char *lastseen);
 
 bool LCH_PatchAppendBlock(const LCH_Json *patch, LCH_Json *block);
 
+bool LCH_PatchReverseBlocks(const LCH_Json *patch);
+
 bool LCH_PatchUpdateLastKnown(const LCH_Json *patch, const char *work_dir,
                               const char *identifier);
 

--- a/lib/table.c
+++ b/lib/table.c
@@ -43,6 +43,7 @@ struct LCH_TableInfo {
   LCH_List *all_fields;
   LCH_List *primary_fields;
   LCH_List *subsidiary_fields;
+  bool merge_blocks;
 
   void *src_dlib_handle;
   char *src_params;
@@ -132,6 +133,14 @@ LCH_TableInfo *LCH_TableInfoLoad(const char *const identifer,
   if (info->subsidiary_fields == NULL) {
     LCH_TableInfoDestroy(info);
     return NULL;
+  }
+
+  info->merge_blocks = true;
+  {
+    const LCH_Buffer key = LCH_BufferStaticFromString("merge_blocks");
+    if (LCH_JsonObjectHasKey(definition, &key)) {
+      info->merge_blocks = LCH_JsonObjectChildIsTrue(definition, &key);
+    }
   }
 
   const LCH_Buffer primary_fields_key =

--- a/lib/table.c
+++ b/lib/table.c
@@ -427,6 +427,11 @@ const char *LCH_TableInfoGetIdentifier(const LCH_TableInfo *const table_info) {
   return table_info->identifier;
 }
 
+bool LCH_TableInfoShouldMergeTable(const LCH_TableInfo *const table_info) {
+  assert(table_info != NULL);
+  return table_info->merge_blocks;
+}
+
 LCH_Json *LCH_TableInfoLoadNewState(const LCH_TableInfo *const table_info) {
   assert(table_info != NULL);
 

--- a/lib/table.h
+++ b/lib/table.h
@@ -16,6 +16,13 @@ LCH_TableInfo *LCH_TableInfoLoad(const char *identifer,
 
 const char *LCH_TableInfoGetIdentifier(const LCH_TableInfo *table_info);
 
+/**
+ * @brief Whether or not the "merge_blocks" field is set for this table
+ * @param table_info The table definition
+ * @return True if table should be merged, otherwise false
+ */
+bool LCH_TableInfoShouldMergeTable(const LCH_TableInfo *table_info);
+
 LCH_Json *LCH_TableInfoLoadNewState(const LCH_TableInfo *table_info);
 
 LCH_Json *LCH_TableInfoLoadOldState(const LCH_TableInfo *table_info,

--- a/tests/test_leech.py
+++ b/tests/test_leech.py
@@ -1230,3 +1230,120 @@ def test_leech_history(tmp_path):
 
     assert len(history["history"]) == 3
     assert history["history"][1]["subsidiary"]["born"] == "1944"
+
+
+def test_disable_mering_blocks(tmp_path):
+    ##########################################################################
+    # Create config
+    ##########################################################################
+
+    bin_path = os.path.join("bin", "leech")
+    leech_conf_path = os.path.join(tmp_path, "leech.json")
+    btl_src_path = os.path.join(tmp_path, "beatles.src.csv")
+    btl_dst_path = os.path.join(tmp_path, "beatles.dst.csv")
+    pfl_src_path = os.path.join(tmp_path, "pinkfloyd.src.csv")
+    pfl_dst_path = os.path.join(tmp_path, "pinkfloyd.dst.csv")
+
+    config = {
+        "version": "0.1.0",
+        "pretty_print": True,
+        "tables": {
+            "BTL": {
+                "primary_fields": ["first_name", "last_name"],
+                "subsidiary_fields": ["born"],
+                "merge_blocks": True,
+                "source": {
+                    "params": btl_src_path,
+                    "schema": "leech",
+                    "table_name": "beatles",
+                    "callbacks": "lib/.libs/leech_csv.so",
+                },
+                "destination": {
+                    "params": btl_dst_path,
+                    "schema": "leech",
+                    "table_name": "beatles",
+                    "callbacks": "lib/.libs/leech_csv.so",
+                },
+            },
+            "PFL": {
+                "primary_fields": ["first_name", "last_name"],
+                "subsidiary_fields": ["born"],
+                "merge_blocks": False,
+                "source": {
+                    "params": pfl_src_path,
+                    "schema": "leech",
+                    "table_name": "pinkfloyd",
+                    "callbacks": "lib/.libs/leech_csv.so",
+                },
+                "destination": {
+                    "params": pfl_dst_path,
+                    "schema": "leech",
+                    "table_name": "pinkfloyd",
+                    "callbacks": "lib/.libs/leech_csv.so",
+                },
+            },
+        },
+    }
+    with open(leech_conf_path, "w") as f:
+        json.dump(config, f, indent=2)
+    print(f"Created leech config '{leech_conf_path}' with content:")
+    with open(leech_conf_path, "r") as f:
+        print(f.read())
+
+    ##########################################################################
+    # Create tables and commit 5 times
+    ##########################################################################
+
+    for born in range(1942, 1947):
+        table = [
+            ["first_name", "last_name", "born"],
+            ["Paul", "McCartney", f"{born}"],
+            ["Ringo", "Starr", "1940"],
+            ["John", "Lennon", "1940"],
+            ["George", "Harrison", "1943"],
+        ]
+
+        for path in (btl_src_path, pfl_src_path):
+            with open(path, "w", newline="") as f:
+                writer = csv.writer(f)
+                writer.writerows(table)
+            print(f"Created table '{path}' with content:")
+            with open(path, "r") as f:
+                print(f.read())
+
+        command = [bin_path, "--debug", f"--workdir={tmp_path}", "commit"]
+        assert execute(command, True) == 0
+
+        # Make sure the timestamp changes in the blocks
+        time.sleep(1)
+
+    ##########################################################################
+    # Create delta patch file
+    ##########################################################################
+
+    lastknown = "0000000000000000000000000000000000000000"
+    patchfile = os.path.join(tmp_path, "patchfile")
+    command = [
+        bin_path,
+        "--debug",
+        f"--workdir={tmp_path}",
+        "diff",
+        f"--block={lastknown}",
+        f"--file={patchfile}",
+    ]
+    assert execute(command, True) == 0
+
+    ##########################################################################
+    # Apply delta patch file
+    ##########################################################################
+
+    command = [
+        bin_path,
+        "--debug",
+        f"--workdir={tmp_path}",
+        "patch",
+        "--field=host_id",
+        "--value=SHA=123",
+        f"--file={patchfile}",
+    ]
+    assert execute(command, True) == 0

--- a/tests/unit/check_json.c
+++ b/tests/unit/check_json.c
@@ -1,5 +1,6 @@
 #include <check.h>
 
+#include "../lib/definitions.h"
 #include "../lib/json.h"
 #include "../lib/string_lib.h"
 
@@ -1066,6 +1067,27 @@ START_TEST(test_LCH_JsonObjectKeysSetIntersectAndValuesSetMinus) {
 }
 END_TEST
 
+START_TEST(test_LCH_JsonArrayReverse) {
+  LCH_Json *const array = LCH_JsonArrayCreate();
+  const char *strs[] = {"one", "two", "three"};
+  for (size_t i = 0; i < LCH_LENGTH(strs); i++) {
+    LCH_Buffer *const buffer = LCH_BufferFromString(strs[i]);
+    ck_assert_ptr_nonnull(buffer);
+    ck_assert(LCH_JsonArrayAppendString(array, buffer));
+  }
+
+  LCH_JsonArrayReverse(array);
+
+  for (size_t i = 0; i < LCH_LENGTH(strs); i++) {
+    const LCH_Buffer *const buffer = LCH_JsonArrayGetString(array, i);
+    ck_assert_ptr_nonnull(buffer);
+    ck_assert_str_eq(LCH_BufferData(buffer), strs[LCH_LENGTH(strs) - 1 - i]);
+  }
+
+  LCH_JsonDestroy(array);
+}
+END_TEST
+
 Suite *JSONSuite(void) {
   Suite *s = suite_create("json.c");
   {
@@ -1345,6 +1367,11 @@ Suite *JSONSuite(void) {
   {
     TCase *tc = tcase_create("LCH_JsonObjectKeysSetIntersectAndValuesSetMinus");
     tcase_add_test(tc, test_LCH_JsonObjectKeysSetIntersectAndValuesSetMinus);
+    suite_add_tcase(s, tc);
+  }
+  {
+    TCase *tc = tcase_create("LCH_JsonArrayReverse");
+    tcase_add_test(tc, test_LCH_JsonArrayReverse);
     suite_add_tcase(s, tc);
   }
   return s;

--- a/tests/unit/check_list.c
+++ b/tests/unit/check_list.c
@@ -83,6 +83,37 @@ START_TEST(test_LCH_ListIndex) {
 }
 END_TEST
 
+START_TEST(test_LCH_ListReverse) {
+  LCH_List *list = LCH_ListCreate();
+  ck_assert_ptr_nonnull(list);
+
+  LCH_ListReverse(list);
+
+  const char *strs[] = {"one", "two", "three", "four"};
+
+  for (size_t i = 0; i < LCH_LENGTH(strs); i++) {
+    ck_assert(LCH_ListAppend(list, (void *)strs[i], NULL));
+  }
+
+  LCH_ListReverse(list);
+
+  ck_assert_str_eq(LCH_ListGet(list, 0), "four");
+  ck_assert_str_eq(LCH_ListGet(list, 1), "three");
+  ck_assert_str_eq(LCH_ListGet(list, 2), "two");
+  ck_assert_str_eq(LCH_ListGet(list, 3), "one");
+
+  ck_assert(LCH_ListRemove(list, 0));
+
+  LCH_ListReverse(list);
+
+  ck_assert_str_eq(LCH_ListGet(list, 0), "one");
+  ck_assert_str_eq(LCH_ListGet(list, 1), "two");
+  ck_assert_str_eq(LCH_ListGet(list, 2), "three");
+
+  LCH_ListDestroy(list);
+}
+END_TEST
+
 Suite *ListSuite(void) {
   Suite *s = suite_create("list.c");
   {
@@ -103,6 +134,11 @@ Suite *ListSuite(void) {
   {
     TCase *tc = tcase_create("LCH_ListIndex");
     tcase_add_test(tc, test_LCH_ListIndex);
+    suite_add_tcase(s, tc);
+  }
+  {
+    TCase *tc = tcase_create("LCH_ListReverse");
+    tcase_add_test(tc, test_LCH_ListReverse);
     suite_add_tcase(s, tc);
   }
   return s;


### PR DESCRIPTION
- **Add docs `"merge_blocks"` parameter**
- **Added pytest for testing disabling of merging**
- **Now parses the `"merge_blocks"` field**
- **Now adds child block to patch if not empty after merging with parent**
- **You can now disable the merging of specific tables**
